### PR TITLE
all: revert to original `&char` call signatures

### DIFF
--- a/audio.c.v
+++ b/audio.c.v
@@ -444,8 +444,8 @@ fn C.SDL_LoadWAV(file &char, spec &C.SDL_AudioSpec, audio_buf &&byte, audio_len 
 
 // load_wav loads a WAV from a file.
 // Compatibility convenience function.
-pub fn load_wav(file string, spec &AudioSpec, audio_buf &&byte, audio_len &u32) &AudioSpec {
-	return C.SDL_LoadWAV(file.str, spec, audio_buf, audio_len)
+pub fn load_wav(file &char, spec &AudioSpec, audio_buf &&byte, audio_len &u32) &AudioSpec {
+	return C.SDL_LoadWAV(file, spec, audio_buf, audio_len)
 }
 
 fn C.SDL_FreeWAV(audio_buf &byte)

--- a/clipboard.c.v
+++ b/clipboard.c.v
@@ -12,8 +12,8 @@ fn C.SDL_SetClipboardText(text &char) int
 // set_clipboard_text puts UTF-8 text into the clipboard
 //
 // See also: SDL_GetClipboardText()
-pub fn set_clipboard_text(text string) int {
-	return C.SDL_SetClipboardText(text.str)
+pub fn set_clipboard_text(text &char) int {
+	return C.SDL_SetClipboardText(text)
 }
 
 fn C.SDL_GetClipboardText() &char
@@ -21,8 +21,8 @@ fn C.SDL_GetClipboardText() &char
 // get_clipboard_text gets UTF-8 text from the clipboard, which must be freed with SDL_free()
 //
 // See also: SDL_SetClipboardText()
-pub fn get_clipboard_text() string {
-	return unsafe { cstring_to_vstring(C.SDL_GetClipboardText()) }
+pub fn get_clipboard_text() &char {
+	return C.SDL_GetClipboardText()
 }
 
 fn C.SDL_HasClipboardText() bool

--- a/error.c.v
+++ b/error.c.v
@@ -14,8 +14,8 @@ extern DECLSPEC int SDLCALL SDL_SetError(SDL_PRINTF_FORMAT_STRING const char *fm
 fn C.SDL_GetError() &char
 
 // get_error SDL_SetError() unconditionally returns -1.
-pub fn get_error() string {
-	return unsafe { cstring_to_vstring(C.SDL_GetError()) }
+pub fn get_error() &char {
+	return C.SDL_GetError()
 }
 
 fn C.SDL_ClearError()

--- a/examples/basic_window/main.v
+++ b/examples/basic_window/main.v
@@ -4,7 +4,7 @@ import sdl
 
 fn main() {
 	sdl.init(sdl.init_video)
-	window := sdl.create_window('Hello SDL2', 300, 300, 500, 300, 0)
+	window := sdl.create_window('Hello SDL2'.str, 300, 300, 500, 300, 0)
 	renderer := sdl.create_renderer(window, -1, u32(sdl.RendererFlags.accelerated) | u32(sdl.RendererFlags.presentvsync))
 
 	mut should_close := false

--- a/examples/tvintris/tvintris.v
+++ b/examples/tvintris/tvintris.v
@@ -228,7 +228,7 @@ fn (mut sdlc SdlContext) set_sdl_context(w int, h int, titl string) {
 	bpp := 32
 	sdl.create_window_and_renderer(w, h, 0, &sdlc.window, &sdlc.renderer)
 	//	sdl.create_window_and_renderer(w, h, 0, &sdlc.window, &sdlc.renderer)
-	sdl.set_window_title(sdlc.window, titl)
+	sdl.set_window_title(sdlc.window, titl.str)
 	sdlc.w = w
 	sdlc.h = h
 	sdlc.screen = sdl.create_rgb_surface(0, w, h, bpp, 0x00FF0000, 0x0000FF00, 0x000000FF,
@@ -242,10 +242,10 @@ fn (mut sdlc SdlContext) set_sdl_context(w int, h int, titl string) {
 		println("couldn't open audio")
 	}
 	println('opening music $music_name')
-	sdlc.actx.music = mix.load_mus(music_name)
-	sdlc.actx.waves[0] = mix.load_wav(snd_block_name)
-	sdlc.actx.waves[1] = mix.load_wav(snd_line_name)
-	sdlc.actx.waves[2] = mix.load_wav(snd_double_name)
+	sdlc.actx.music = mix.load_mus(music_name.str)
+	sdlc.actx.waves[0] = mix.load_wav(snd_block_name.str)
+	sdlc.actx.waves[1] = mix.load_wav(snd_line_name.str)
+	sdlc.actx.waves[2] = mix.load_wav(snd_double_name.str)
 	sdlc.actx.volume = mix.maxvolume
 	if mix.play_music(sdlc.actx.music, 1) != -1 {
 		mix.volume_music(sdlc.actx.volume)
@@ -268,7 +268,7 @@ fn (mut sdlc SdlContext) set_sdl_context(w int, h int, titl string) {
 		println('error initializing image library.')
 	}
 	println('opening logo $v_logo')
-	sdlc.v_logo = img.load(v_logo)
+	sdlc.v_logo = img.load(v_logo.str)
 	if !isnil(sdlc.v_logo) {
 		//		println('got v_logo=$sdlc.v_logo')
 		sdlc.tv_logo = sdl.create_texture_from_surface(sdlc.renderer, sdlc.v_logo)
@@ -287,7 +287,7 @@ fn main() {
 	game.sdl.jids[0] = -1
 	game.sdl.jids[1] = -1
 	game.sdl.set_sdl_context(win_width, win_height, title)
-	game.font = ttf.open_font(font_name, text_size)
+	game.font = ttf.open_font(font_name.str, text_size)
 	mut game2 := &Game{
 		font: 0
 	}

--- a/examples/version/main.v
+++ b/examples/version/main.v
@@ -4,5 +4,7 @@ module main
 import sdl
 
 fn main() {
-	println(sdl.version())
+	mut v := sdl.Version{}
+	sdl.version(mut v)
+	println(v.str())
 }

--- a/examples/versions/main.v
+++ b/examples/versions/main.v
@@ -5,7 +5,11 @@ import sdl
 fn main() {
 	println('v.mod version $sdl.vmod_version()')
 	println('Const version ${sdl.major_version}.${sdl.minor_version}.$sdl.patchlevel')
-	println('Compiled against version $sdl.version()')
-	println('Runtime loaded version $sdl.get_version()')
+	mut compiled_version := sdl.Version{}
+	sdl.version(mut compiled_version)
+	println('Compiled against version $compiled_version.str()')
+	mut linked_version := sdl.Version{}
+	sdl.get_version(mut linked_version)
+	println('Runtime loaded version $linked_version.str()')
 	println('Revision $sdl.get_revision_number() / $sdl.get_revision()')
 }

--- a/filesystem.c.v
+++ b/filesystem.c.v
@@ -30,8 +30,8 @@ fn C.SDL_GetBasePath() &char
 //  returns String of base dir in UTF-8 encoding, or NULL on error.
 //
 // See also: SDL_GetPrefPath
-pub fn get_base_path() string {
-	return unsafe { cstring_to_vstring(C.SDL_GetBasePath()) }
+pub fn get_base_path() &char {
+	return C.SDL_GetBasePath()
 }
 
 fn C.SDL_GetPrefPath(org &char, app &char) &char
@@ -95,6 +95,6 @@ fn C.SDL_GetPrefPath(org &char, app &char) &char
 //          if there's a problem (creating directory failed, etc).
 //
 // See also: SDL_GetBasePath
-pub fn get_pref_path(org string, app string) &char {
-	return C.SDL_GetPrefPath(org.str, app.str)
+pub fn get_pref_path(org &char, app &char) &char {
+	return C.SDL_GetPrefPath(org, app)
 }

--- a/gamecontroller.c.v
+++ b/gamecontroller.c.v
@@ -93,8 +93,8 @@ fn C.SDL_GameControllerAddMappingsFromFile(file &char) int
 // game_controller_add_mappings_from_file loads a set of mappings from a file, filtered by the current SDL_GetPlatform()
 //
 // Convenience macro.
-pub fn game_controller_add_mappings_from_file(file string) int {
-	return C.SDL_GameControllerAddMappingsFromFile(file.str)
+pub fn game_controller_add_mappings_from_file(file &char) int {
+	return C.SDL_GameControllerAddMappingsFromFile(file)
 }
 
 fn C.SDL_GameControllerAddMapping(mapping_string &char) int
@@ -102,8 +102,8 @@ fn C.SDL_GameControllerAddMapping(mapping_string &char) int
 // game_controller_add_mapping adds or updates an existing mapping configuration
 //
 // returns 1 if mapping is added, 0 if updated, -1 on error
-pub fn game_controller_add_mapping(mapping_string string) int {
-	return C.SDL_GameControllerAddMapping(mapping_string.str)
+pub fn game_controller_add_mapping(mapping_string &char) int {
+	return C.SDL_GameControllerAddMapping(mapping_string)
 }
 
 fn C.SDL_GameControllerNumMappings() int
@@ -120,14 +120,8 @@ fn C.SDL_GameControllerMappingForIndex(mapping_index int) &char
 // game_controller_mapping_for_index gets the mapping at a particular index.
 //
 // returns the mapping string.  Must be freed with SDL_free().  Returns NULL if the index is out of range.
-pub fn game_controller_mapping_for_index(mapping_index int) string {
-	cstr := C.SDL_GameControllerMappingForIndex(mapping_index)
-	mut vstr := ''
-	if !isnil(cstr) {
-		vstr = unsafe { cstring_to_vstring(cstr) }
-		unsafe { free(cstr) }
-	}
-	return vstr
+pub fn game_controller_mapping_for_index(mapping_index int) &char {
+	return C.SDL_GameControllerMappingForIndex(mapping_index)
 }
 
 fn C.SDL_GameControllerMappingForGUID(guid C.SDL_JoystickGUID) &char
@@ -135,14 +129,8 @@ fn C.SDL_GameControllerMappingForGUID(guid C.SDL_JoystickGUID) &char
 // Get a mapping string for a GUID
 //
 // returns the mapping string.  Must be freed with SDL_free().  Returns NULL if no mapping is available
-pub fn game_controller_mapping_for_guid(guid JoystickGUID) string {
-	cstr := C.SDL_GameControllerMappingForGUID(guid)
-	mut vstr := ''
-	if !isnil(cstr) {
-		vstr = unsafe { cstring_to_vstring(cstr) }
-		unsafe { free(cstr) }
-	}
-	return vstr
+pub fn game_controller_mapping_for_guid(guid JoystickGUID) &char {
+	return C.SDL_GameControllerMappingForGUID(guid)
 }
 
 fn C.SDL_GameControllerMapping(gamecontroller &C.SDL_GameController) &char
@@ -150,14 +138,8 @@ fn C.SDL_GameControllerMapping(gamecontroller &C.SDL_GameController) &char
 // game_controller_mapping gets a mapping string for an open GameController
 //
 // returns the mapping string.  Must be freed with SDL_free().  Returns NULL if no mapping is available
-pub fn game_controller_mapping(gamecontroller &GameController) string {
-	cstr := C.SDL_GameControllerMapping(gamecontroller)
-	mut vstr := ''
-	if !isnil(cstr) {
-		vstr = unsafe { cstring_to_vstring(cstr) }
-		unsafe { free(cstr) }
-	}
-	return vstr
+pub fn game_controller_mapping(gamecontroller &GameController) &char {
+	return C.SDL_GameControllerMapping(gamecontroller)
 }
 
 fn C.SDL_IsGameController(joystick_index int) bool
@@ -172,14 +154,8 @@ fn C.SDL_GameControllerNameForIndex(joystick_index int) &char
 // game_controller_name_for_index gets the implementation dependent name of a game controller.
 // This can be called before any controllers are opened.
 // If no name can be found, this function returns NULL.
-pub fn game_controller_name_for_index(joystick_index int) string {
-	cstr := C.SDL_GameControllerNameForIndex(joystick_index)
-	mut vstr := ''
-	if !isnil(cstr) {
-		vstr = unsafe { cstring_to_vstring(cstr) }
-		// unsafe { free(cstr) }
-	}
-	return vstr
+pub fn game_controller_name_for_index(joystick_index int) &char {
+	return C.SDL_GameControllerNameForIndex(joystick_index)
 }
 
 fn C.SDL_GameControllerOpen(joystick_index int) &C.SDL_GameController
@@ -205,8 +181,8 @@ pub fn game_controller_from_instance_id(joyid JoystickID) &GameController {
 fn C.SDL_GameControllerName(gamecontroller &C.SDL_GameController) &char
 
 // game_controller_name returns the name for this currently opened controller
-pub fn game_controller_name(gamecontroller &GameController) string {
-	return unsafe { cstring_to_vstring(C.SDL_GameControllerName(gamecontroller)) }
+pub fn game_controller_name(gamecontroller &GameController) &char {
+	return C.SDL_GameControllerName(gamecontroller)
 }
 
 fn C.SDL_GameControllerGetVendor(gamecontroller &C.SDL_GameController) u16
@@ -294,21 +270,15 @@ pub enum GameControllerAxis {
 fn C.SDL_GameControllerGetAxisFromString(pch_string &char) C.SDL_GameControllerAxis
 
 // game_controller_get_axis_from_string turns the string into an axis mapping
-pub fn game_controller_get_axis_from_string(pch_string string) GameControllerAxis {
-	return GameControllerAxis(C.SDL_GameControllerGetAxisFromString(pch_string.str))
+pub fn game_controller_get_axis_from_string(pch_string &char) GameControllerAxis {
+	return GameControllerAxis(C.SDL_GameControllerGetAxisFromString(pch_string))
 }
 
 // game_controller_get_string_for_axis turns the axis enum into a string mapping
 ///
 fn C.SDL_GameControllerGetStringForAxis(axis C.SDL_GameControllerAxis) &char
-pub fn game_controller_get_string_for_axis(axis GameControllerAxis) string {
-	cstr := C.SDL_GameControllerGetStringForAxis(C.SDL_GameControllerAxis(axis))
-	mut vstr := ''
-	if !isnil(cstr) {
-		vstr = unsafe { cstring_to_vstring(cstr) }
-		// unsafe { free(cstr) }
-	}
-	return vstr
+pub fn game_controller_get_string_for_axis(axis GameControllerAxis) &char {
+	return C.SDL_GameControllerGetStringForAxis(C.SDL_GameControllerAxis(axis))
 }
 
 fn C.SDL_GameControllerGetBindForAxis(gamecontroller &C.SDL_GameController, axis C.SDL_GameControllerAxis) C.SDL_GameControllerButtonBind
@@ -355,21 +325,15 @@ pub enum GameControllerButton {
 fn C.SDL_GameControllerGetButtonFromString(pch_string &char) C.SDL_GameControllerButton
 
 // game_controller_get_button_from_string turns the string into a button mapping
-pub fn game_controller_get_button_from_string(pch_string string) GameControllerButton {
-	return GameControllerButton(C.SDL_GameControllerGetButtonFromString(pch_string.str))
+pub fn game_controller_get_button_from_string(pch_string &char) GameControllerButton {
+	return GameControllerButton(C.SDL_GameControllerGetButtonFromString(pch_string))
 }
 
 // game_controller_get_string_for_button turns the button enum into a string mapping
 ///
 fn C.SDL_GameControllerGetStringForButton(button C.SDL_GameControllerButton) &char
-pub fn game_controller_get_string_for_button(button GameControllerButton) string {
-	cstr := C.SDL_GameControllerGetStringForButton(C.SDL_GameControllerButton(button))
-	mut vstr := ''
-	if !isnil(cstr) {
-		vstr = unsafe { cstring_to_vstring(cstr) }
-		// unsafe { free(cstr) }
-	}
-	return vstr
+pub fn game_controller_get_string_for_button(button GameControllerButton) &char {
+	return C.SDL_GameControllerGetStringForButton(C.SDL_GameControllerButton(button))
 }
 
 fn C.SDL_GameControllerGetBindForButton(gamecontroller &C.SDL_GameController, button C.SDL_GameControllerButton) C.SDL_GameControllerButtonBind

--- a/haptic.c.v
+++ b/haptic.c.v
@@ -579,8 +579,8 @@ fn C.SDL_HapticName(device_index int) &char
 // returns Name of the device or NULL on error.
 //
 // See also: SDL_NumHaptics
-pub fn haptic_name(device_index int) string {
-	return unsafe { cstring_to_vstring(C.SDL_HapticName(device_index)) }
+pub fn haptic_name(device_index int) &char {
+	return C.SDL_HapticName(device_index)
 }
 
 fn C.SDL_HapticOpen(device_index int) &C.SDL_Haptic

--- a/hints.c.v
+++ b/hints.c.v
@@ -776,8 +776,8 @@ fn C.SDL_SetHintWithPriority(name &char, value &char, priority C.SDL_HintPriorit
 // lower.  Environment variables are considered to have override priority.
 //
 // returns SDL_TRUE if the hint was set, SDL_FALSE otherwise
-pub fn set_hint_with_priority(name string, value string, priority HintPriority) bool {
-	return C.SDL_SetHintWithPriority(name.str, value.str, C.SDL_HintPriority(priority))
+pub fn set_hint_with_priority(name &char, value &char, priority HintPriority) bool {
+	return C.SDL_SetHintWithPriority(name, value, C.SDL_HintPriority(priority))
 }
 
 fn C.SDL_SetHint(name &char, value &char) bool
@@ -785,8 +785,8 @@ fn C.SDL_SetHint(name &char, value &char) bool
 // set_hint sets a hint with normal priority
 //
 // returns SDL_TRUE if the hint was set, SDL_FALSE otherwise
-pub fn set_hint(name string, value string) bool {
-	return C.SDL_SetHint(name.str, value.str)
+pub fn set_hint(name &char, value &char) bool {
+	return C.SDL_SetHint(name, value)
 }
 
 fn C.SDL_GetHint(name &char) &char
@@ -794,8 +794,8 @@ fn C.SDL_GetHint(name &char) &char
 // get_hint gets a hint
 //
 // returns The string value of a hint variable.
-pub fn get_hint(name string) string {
-	return unsafe { cstring_to_vstring(C.SDL_GetHint(name.str)) }
+pub fn get_hint(name &char) &char {
+	return C.SDL_GetHint(name)
 }
 
 fn C.SDL_GetHintBoolean(name &char, default_value bool) bool
@@ -803,8 +803,8 @@ fn C.SDL_GetHintBoolean(name &char, default_value bool) bool
 // get_hint_boolean gets a hint
 //
 // returns The boolean value of a hint variable.
-pub fn get_hint_boolean(name string, default_value bool) bool {
-	return C.SDL_GetHintBoolean(name.str, default_value)
+pub fn get_hint_boolean(name &char, default_value bool) bool {
+	return C.SDL_GetHintBoolean(name, default_value)
 }
 
 // HintCallback type definition of the hint callback function.
@@ -818,8 +818,8 @@ fn C.SDL_AddHintCallback(name &char, callback HintCallback, userdata voidptr)
 // `name` The hint to watch
 // `callback` The function to call when the hint value changes
 // `userdata` A pointer to pass to the callback function
-pub fn add_hint_callback(name string, callback HintCallback, userdata voidptr) {
-	C.SDL_AddHintCallback(name.str, callback, userdata)
+pub fn add_hint_callback(name &char, callback HintCallback, userdata voidptr) {
+	C.SDL_AddHintCallback(name, callback, userdata)
 }
 
 fn C.SDL_DelHintCallback(name &char, callback HintCallback, userdata voidptr)
@@ -829,8 +829,8 @@ fn C.SDL_DelHintCallback(name &char, callback HintCallback, userdata voidptr)
 // `name` The hint being watched
 // `callback` The function being called when the hint value changes
 // `userdata` A pointer being passed to the callback function
-pub fn del_hint_callback(name string, callback HintCallback, userdata voidptr) {
-	C.SDL_DelHintCallback(name.str, callback, userdata)
+pub fn del_hint_callback(name &char, callback HintCallback, userdata voidptr) {
+	C.SDL_DelHintCallback(name, callback, userdata)
 }
 
 fn C.SDL_ClearHints()

--- a/image/image.c.v
+++ b/image/image.c.v
@@ -68,14 +68,14 @@ fn C.IMG_LoadTyped_RW(src &C.SDL_RWops, freesrc int, @type &char) &C.SDL_Surface
 // colorkey for the surface.  You can enable RLE acceleration on the
 // surface afterwards by calling:
 // SDL_SetColorKey(image, SDL_RLEACCEL, image->format->colorkey);
-pub fn load_typed_rw(src &sdl.RWops, freesrc int, @type string) &sdl.Surface {
-	return C.IMG_LoadTyped_RW(src, freesrc, @type.str)
+pub fn load_typed_rw(src &sdl.RWops, freesrc int, @type &char) &sdl.Surface {
+	return C.IMG_LoadTyped_RW(src, freesrc, @type)
 }
 
 // Convenience functions
 fn C.IMG_Load(file &char) &C.SDL_Surface
-pub fn load(file string) &sdl.Surface {
-	return C.IMG_Load(file.str)
+pub fn load(file &char) &sdl.Surface {
+	return C.IMG_Load(file)
 }
 
 fn C.IMG_Load_RW(src &C.SDL_RWops, freesrc int) &C.SDL_Surface
@@ -85,8 +85,8 @@ pub fn load_rw(src &sdl.RWops, freesrc int) &sdl.Surface {
 
 // load_texture loads an image directly into a render texture.
 fn C.IMG_LoadTexture(renderer &C.SDL_Renderer, file &char) &C.SDL_Texture
-pub fn load_texture(renderer &sdl.Renderer, file string) &sdl.Texture {
-	return C.IMG_LoadTexture(renderer, file.str)
+pub fn load_texture(renderer &sdl.Renderer, file &char) &sdl.Texture {
+	return C.IMG_LoadTexture(renderer, file)
 }
 
 fn C.IMG_LoadTexture_RW(renderer &C.SDL_Renderer, src &C.SDL_RWops, freesrc int) &C.SDL_Texture
@@ -263,8 +263,8 @@ pub fn read_xpm_from_array(xpm &&char) &sdl.Surface {
 
 // Individual saving functions
 fn C.IMG_SavePNG(surface &C.SDL_Surface, file &char) int
-pub fn save_png(surface &sdl.Surface, file string) int {
-	return C.IMG_SavePNG(surface, file.str)
+pub fn save_png(surface &sdl.Surface, file &char) int {
+	return C.IMG_SavePNG(surface, file)
 }
 
 fn C.IMG_SavePNG_RW(surface &C.SDL_Surface, dst &C.SDL_RWops, freedst int) int

--- a/joystick.c.v
+++ b/joystick.c.v
@@ -177,8 +177,8 @@ fn C.SDL_JoystickName(joystick &C.SDL_Joystick) &char
 
 // joystick_name returns the name for this currently opened joystick.
 // If no name can be found, this function returns NULL.
-pub fn joystick_name(joystick &Joystick) string {
-	return unsafe { cstring_to_vstring(C.SDL_JoystickName(joystick)) }
+pub fn joystick_name(joystick &Joystick) &char {
+	return C.SDL_JoystickName(joystick)
 }
 
 fn C.SDL_JoystickGetGUID(joystick &C.SDL_Joystick) C.SDL_JoystickGUID

--- a/keyboard.c.v
+++ b/keyboard.c.v
@@ -99,8 +99,8 @@ fn C.SDL_GetScancodeName(scancode C.SDL_Scancode) &char
 //         an empty string ("").
 //
 // See also: SDL_Scancode
-pub fn get_scancode_name(scancode Scancode) string {
-	return unsafe { cstring_to_vstring(C.SDL_GetScancodeName(C.SDL_Scancode(scancode))) }
+pub fn get_scancode_name(scancode Scancode) &char {
+	return C.SDL_GetScancodeName(C.SDL_Scancode(scancode))
 }
 
 fn C.SDL_GetScancodeFromName(name &char) C.SDL_Scancode
@@ -110,8 +110,8 @@ fn C.SDL_GetScancodeFromName(name &char) C.SDL_Scancode
 // returns scancode, or SDL_SCANCODE_UNKNOWN if the name wasn't recognized
 //
 // See also: SDL_Scancode
-pub fn get_scancode_from_name(name string) Scancode {
-	return Scancode(int(C.SDL_GetScancodeFromName(name.str)))
+pub fn get_scancode_from_name(name &char) Scancode {
+	return Scancode(int(C.SDL_GetScancodeFromName(name)))
 }
 
 fn C.SDL_GetKeyName(key C.SDL_Keycode) &char
@@ -124,8 +124,8 @@ fn C.SDL_GetKeyName(key C.SDL_Keycode) &char
 //         empty string ("").
 //
 // See also: SDL_Keycode
-pub fn get_key_name(key Keycode) string {
-	return unsafe { cstring_to_vstring(C.SDL_GetKeyName(C.SDL_Keycode(key))) }
+pub fn get_key_name(key Keycode) &char {
+	return C.SDL_GetKeyName(C.SDL_Keycode(key))
 }
 
 fn C.SDL_GetKeyFromName(name &char) C.SDL_Keycode
@@ -135,8 +135,8 @@ fn C.SDL_GetKeyFromName(name &char) C.SDL_Keycode
 // returns key code, or SDLK_UNKNOWN if the name wasn't recognized
 //
 // See also: SDL_Keycode
-pub fn get_key_from_name(name string) Keycode {
-	return Keycode(int(C.SDL_GetKeyFromName(name.str)))
+pub fn get_key_from_name(name &char) Keycode {
+	return Keycode(int(C.SDL_GetKeyFromName(name)))
 }
 
 fn C.SDL_StartTextInput()

--- a/loadso.c.v
+++ b/loadso.c.v
@@ -11,8 +11,8 @@ fn C.SDL_LoadObject(sofile &char) voidptr
 // load_object dynamically loads a shared object and returns a pointer
 // to the object handle (or NULL if there was an error).
 // The 'sofile' parameter is a system dependent name of the object file.
-pub fn load_object(sofile string) voidptr {
-	return C.SDL_LoadObject(sofile.str)
+pub fn load_object(sofile &char) voidptr {
+	return C.SDL_LoadObject(sofile)
 }
 
 fn C.SDL_LoadFunction(handle voidptr, name &char) voidptr
@@ -20,8 +20,8 @@ fn C.SDL_LoadFunction(handle voidptr, name &char) voidptr
 // load_function, given an object handle, looks up the address of the
 // named function in the shared object and returns it.  This address
 // is no longer valid after calling SDL_UnloadObject().
-pub fn load_function(handle voidptr, name string) voidptr {
-	return C.SDL_LoadFunction(handle, name.str)
+pub fn load_function(handle voidptr, name &char) voidptr {
+	return C.SDL_LoadFunction(handle, name)
 }
 
 fn C.SDL_UnloadObject(handle voidptr)

--- a/log.c.v
+++ b/log.c.v
@@ -106,8 +106,8 @@ pub fn log_reset_priorities() {
 fn C.SDL_LogMessageV(category int, priority C.SDL_LogPriority, fmt &char, ap C.va_list)
 
 // log_message_v logs a message with the specified category and priority.
-pub fn log_message_v(category int, priority LogPriority, fmt string, ap C.va_list) {
-	C.SDL_LogMessageV(category, C.SDL_LogPriority(priority), fmt.str, ap)
+pub fn log_message_v(category int, priority LogPriority, fmt &char, ap C.va_list) {
+	C.SDL_LogMessageV(category, C.SDL_LogPriority(priority), fmt, ap)
 }
 
 fn C.SDL_LogGetOutputFunction(callback &LogOutputFunction, userdata voidptr)

--- a/main_windows.c.v
+++ b/main_windows.c.v
@@ -10,8 +10,8 @@ module sdl
 fn C.SDL_RegisterApp(name &char, style u32, h_inst voidptr) int
 
 // register_app can be called to set the application class at startup
-pub fn register_app(name string, style u32, h_inst voidptr) int {
-	return C.SDL_RegisterApp(name.str, style, h_inst)
+pub fn register_app(name &char, style u32, h_inst voidptr) int {
+	return C.SDL_RegisterApp(name, style, h_inst)
 }
 
 fn C.SDL_UnregisterApp()

--- a/messagebox.c.v
+++ b/messagebox.c.v
@@ -104,6 +104,6 @@ fn C.SDL_ShowSimpleMessageBox(flags u32, title &char, message &char, window &C.S
 // returns 0 on success, -1 on error
 //
 // See also: SDL_ShowMessageBox
-pub fn show_simple_message_box(flags u32, title string, message string, window &Window) int {
-	return C.SDL_ShowSimpleMessageBox(flags, title.str, message.str, window)
+pub fn show_simple_message_box(flags u32, title &char, message &char, window &Window) int {
+	return C.SDL_ShowSimpleMessageBox(flags, title, message, window)
 }

--- a/mixer/mixer.c.v
+++ b/mixer/mixer.c.v
@@ -167,16 +167,16 @@ pub fn load_wav_rw(src &sdl.RWops, freesrc int) &Chunk {
 }
 
 fn C.Mix_LoadWAV(file &char) &C.Mix_Chunk
-pub fn load_wav(path string) &Chunk {
-	return C.Mix_LoadWAV(path.str)
+pub fn load_wav(path &char) &Chunk {
+	return C.Mix_LoadWAV(path)
 }
 
 fn C.Mix_LoadMUS(file &char) &C.Mix_Music
 
 // load_mus loads a music file from an SDL_RWop object (Ogg and MikMod specific currently)
 // Matt Campbell (matt@campbellhome.dhs.org) April 2000
-pub fn load_mus(path string) &Music {
-	return C.Mix_LoadMUS(path.str)
+pub fn load_mus(path &char) &Music {
+	return C.Mix_LoadMUS(path)
 }
 
 fn C.Mix_LoadMUS_RW(src &C.SDL_RWops, freesrc int) &C.Mix_Music
@@ -250,8 +250,8 @@ pub fn get_chunk_decoder(index int) &char {
 }
 
 fn C.Mix_HasChunkDecoder(name &char) bool
-pub fn has_chunk_decoder(name string) bool {
-	return C.Mix_HasChunkDecoder(name.str)
+pub fn has_chunk_decoder(name &char) bool {
+	return C.Mix_HasChunkDecoder(name)
 }
 
 fn C.Mix_GetNumMusicDecoders() int
@@ -823,8 +823,8 @@ pub fn playing_music() int {
 fn C.Mix_SetMusicCMD(command &char) int
 
 // set_music_cmd stops music and set external music playback command
-pub fn set_music_cmd(command string) int {
-	return C.Mix_SetMusicCMD(command.str)
+pub fn set_music_cmd(command &char) int {
+	return C.Mix_SetMusicCMD(command)
 }
 
 fn C.Mix_SetSynchroValue(value int) int
@@ -842,8 +842,8 @@ pub fn get_synchro_value() int {
 fn C.Mix_SetSoundFonts(paths &char) int
 
 // set_sound_fonts set/get/iterate SoundFonts paths to use by supported MIDI backends
-pub fn set_sound_fonts(paths string) int {
-	return C.Mix_SetSoundFonts(paths.str)
+pub fn set_sound_fonts(paths &char) int {
+	return C.Mix_SetSoundFonts(paths)
 }
 
 fn C.Mix_GetSoundFonts() &char

--- a/pixels.c.v
+++ b/pixels.c.v
@@ -179,8 +179,8 @@ pub type PixelFormat = C.SDL_PixelFormat
 fn C.SDL_GetPixelFormatName(format Format) &char
 
 // get the human readable name of a pixel format
-pub fn get_pixel_format_name(format Format) string {
-	return unsafe { cstring_to_vstring(C.SDL_GetPixelFormatName(format)) }
+pub fn get_pixel_format_name(format Format) &char {
+	return C.SDL_GetPixelFormatName(format)
 }
 
 fn C.SDL_PixelFormatEnumToMasks(format Format, bpp &int, rmask &u32, gmask &u32, bmask &u32, amask &u32) bool

--- a/platform.c.v
+++ b/platform.c.v
@@ -9,6 +9,6 @@ module sdl
 
 // get_platform gets the name of the platform.
 fn C.SDL_GetPlatform() &char
-pub fn get_platform() string {
-	return unsafe { cstring_to_vstring(C.SDL_GetPlatform()) }
+pub fn get_platform() &char {
+	return C.SDL_GetPlatform()
 }

--- a/rwops.c.v
+++ b/rwops.c.v
@@ -110,8 +110,8 @@ pub fn (rwo &RWops) close() int {
 //
 // Functions to create SDL_RWops structures from various data streams.
 fn C.SDL_RWFromFile(file &char, mode &char) &C.SDL_RWops
-pub fn rw_from_file(file string, mode string) &RWops {
-	return C.SDL_RWFromFile(file.str, mode.str)
+pub fn rw_from_file(file &char, mode &char) &RWops {
+	return C.SDL_RWFromFile(file, mode)
 }
 
 /*

--- a/shape.c.v
+++ b/shape.c.v
@@ -33,8 +33,8 @@ fn C.SDL_CreateShapedWindow(title &char, x u32, y u32, w u32, h u32, flags u32) 
 // returns The window created, or NULL if window creation failed.
 //
 // See also: SDL_DestroyWindow()
-pub fn create_shaped_window(title string, x u32, y u32, w u32, h u32, flags u32) &Window {
-	return C.SDL_CreateShapedWindow(title.str, x, y, w, h, flags)
+pub fn create_shaped_window(title &char, x u32, y u32, w u32, h u32, flags u32) &Window {
+	return C.SDL_CreateShapedWindow(title, x, y, w, h, flags)
 }
 
 fn C.SDL_IsShapedWindow(window &C.SDL_Window) bool

--- a/stdinc.c.v
+++ b/stdinc.c.v
@@ -123,13 +123,13 @@ pub fn get_num_allocations() int {
 }
 
 fn C.SDL_getenv(name &char) &char
-pub fn getenv(name string) &char {
-	return C.SDL_getenv(name.str)
+pub fn getenv(name &char) &char {
+	return C.SDL_getenv(name)
 }
 
 fn C.SDL_setenv(name &char, value &char, overwrite int) int
-pub fn setenv(name string, value string, overwrite int) int {
-	return C.SDL_setenv(name.str, value.str, overwrite)
+pub fn setenv(name &char, value &char, overwrite int) int {
+	return C.SDL_setenv(name, value, overwrite)
 }
 
 // int (*compare) (const void *, const void *)
@@ -224,8 +224,8 @@ pub fn wcscmp(str1 &C.wchar_t, str2 &C.wchar_t) int{
 */
 
 fn C.SDL_strlen(str &char) usize
-pub fn strlen(str string) usize {
-	return C.SDL_strlen(str.str)
+pub fn strlen(str &char) usize {
+	return C.SDL_strlen(str)
 }
 
 /*
@@ -250,128 +250,128 @@ pub fn strlcat(dst &C.SDL_INOUT_Z_CAP(maxlen) char, src &char, maxlen usize) usi
 */
 
 fn C.SDL_strdup(str &char) &char
-pub fn strdup(str string) &char {
-	return C.SDL_strdup(str.str)
+pub fn strdup(str &char) &char {
+	return C.SDL_strdup(str)
 }
 
 fn C.SDL_strrev(str &char) &char
-pub fn strrev(str string) &char {
-	return C.SDL_strrev(str.str)
+pub fn strrev(str &char) &char {
+	return C.SDL_strrev(str)
 }
 
 fn C.SDL_strupr(str &char) &char
-pub fn strupr(str string) &char {
-	return C.SDL_strupr(str.str)
+pub fn strupr(str &char) &char {
+	return C.SDL_strupr(str)
 }
 
 fn C.SDL_strlwr(str &char) &char
-pub fn strlwr(str string) &char {
-	return C.SDL_strlwr(str.str)
+pub fn strlwr(str &char) &char {
+	return C.SDL_strlwr(str)
 }
 
 fn C.SDL_strchr(str &char, c int) &char
-pub fn strchr(str string, c int) &char {
-	return C.SDL_strchr(str.str, c)
+pub fn strchr(str &char, c int) &char {
+	return C.SDL_strchr(str, c)
 }
 
 fn C.SDL_strrchr(str &char, c int) &char
-pub fn strrchr(str string, c int) &char {
-	return C.SDL_strrchr(str.str, c)
+pub fn strrchr(str &char, c int) &char {
+	return C.SDL_strrchr(str, c)
 }
 
 fn C.SDL_strstr(haystack &char, needle &char) &char
-pub fn strstr(haystack string, needle string) &char {
-	return C.SDL_strstr(haystack.str, needle.str)
+pub fn strstr(haystack &char, needle &char) &char {
+	return C.SDL_strstr(haystack, needle)
 }
 
 fn C.SDL_utf8strlen(str &char) usize
-pub fn utf8strlen(str string) usize {
-	return C.SDL_utf8strlen(str.str)
+pub fn utf8strlen(str &char) usize {
+	return C.SDL_utf8strlen(str)
 }
 
 fn C.SDL_itoa(value int, str &char, radix int) &char
-pub fn itoa(value int, str string, radix int) &char {
-	return C.SDL_itoa(value, str.str, radix)
+pub fn itoa(value int, str &char, radix int) &char {
+	return C.SDL_itoa(value, str, radix)
 }
 
 fn C.SDL_uitoa(value u32, str &char, radix int) &char
-pub fn uitoa(value u32, str string, radix int) &char {
-	return C.SDL_uitoa(value, str.str, radix)
+pub fn uitoa(value u32, str &char, radix int) &char {
+	return C.SDL_uitoa(value, str, radix)
 }
 
 fn C.SDL_ltoa(value int, str &char, radix int) &char
-pub fn ltoa(value int, str string, radix int) &char {
-	return C.SDL_ltoa(value, str.str, radix)
+pub fn ltoa(value int, str &char, radix int) &char {
+	return C.SDL_ltoa(value, str, radix)
 }
 
 fn C.SDL_ultoa(value u32, str &char, radix int) &char
-pub fn ultoa(value u32, str string, radix int) &char {
-	return C.SDL_ultoa(value, str.str, radix)
+pub fn ultoa(value u32, str &char, radix int) &char {
+	return C.SDL_ultoa(value, str, radix)
 }
 
 fn C.SDL_lltoa(value C.Sint64, str &char, radix int) &char
-pub fn lltoa(value C.Sint64, str string, radix int) &char {
-	return C.SDL_lltoa(value, str.str, radix)
+pub fn lltoa(value C.Sint64, str &char, radix int) &char {
+	return C.SDL_lltoa(value, str, radix)
 }
 
 fn C.SDL_ulltoa(value u64, str &char, radix int) &char
-pub fn ulltoa(value u64, str string, radix int) &char {
-	return C.SDL_ulltoa(value, str.str, radix)
+pub fn ulltoa(value u64, str &char, radix int) &char {
+	return C.SDL_ulltoa(value, str, radix)
 }
 
 fn C.SDL_atoi(str &char) int
-pub fn atoi(str string) int {
-	return C.SDL_atoi(str.str)
+pub fn atoi(str &char) int {
+	return C.SDL_atoi(str)
 }
 
 fn C.SDL_atof(str &char) f64
-pub fn atof(str string) f64 {
-	return C.SDL_atof(str.str)
+pub fn atof(str &char) f64 {
+	return C.SDL_atof(str)
 }
 
 fn C.SDL_strtol(str &char, endp &&char, base int) int
-pub fn strtol(str string, endp &&char, base int) int {
-	return C.SDL_strtol(str.str, endp, base)
+pub fn strtol(str &char, endp &&char, base int) int {
+	return C.SDL_strtol(str, endp, base)
 }
 
 fn C.SDL_strtoul(str &char, endp &&char, base int) u32
-pub fn strtoul(str string, endp &&char, base int) u32 {
-	return C.SDL_strtoul(str.str, endp, base)
+pub fn strtoul(str &char, endp &&char, base int) u32 {
+	return C.SDL_strtoul(str, endp, base)
 }
 
 fn C.SDL_strtoll(str &char, endp &&char, base int) C.Sint64
-pub fn strtoll(str string, endp &&char, base int) C.Sint64 {
-	return C.SDL_strtoll(str.str, endp, base)
+pub fn strtoll(str &char, endp &&char, base int) C.Sint64 {
+	return C.SDL_strtoll(str, endp, base)
 }
 
 fn C.SDL_strtoull(str &char, endp &&char, base int) u64
-pub fn strtoull(str string, endp &&char, base int) u64 {
-	return C.SDL_strtoull(str.str, endp, base)
+pub fn strtoull(str &char, endp &&char, base int) u64 {
+	return C.SDL_strtoull(str, endp, base)
 }
 
 fn C.SDL_strtod(str &char, endp &&char) f64
-pub fn strtod(str string, endp &&char) f64 {
-	return C.SDL_strtod(str.str, endp)
+pub fn strtod(str &char, endp &&char) f64 {
+	return C.SDL_strtod(str, endp)
 }
 
 fn C.SDL_strcmp(str1 &char, str2 &char) int
-pub fn strcmp(str1 string, str2 string) int {
-	return C.SDL_strcmp(str1.str, str2.str)
+pub fn strcmp(str1 &char, str2 &char) int {
+	return C.SDL_strcmp(str1, str2)
 }
 
 fn C.SDL_strncmp(str1 &char, str2 &char, maxlen usize) int
-pub fn strncmp(str1 string, str2 string, maxlen usize) int {
-	return C.SDL_strncmp(str1.str, str2.str, maxlen)
+pub fn strncmp(str1 &char, str2 &char, maxlen usize) int {
+	return C.SDL_strncmp(str1, str2, maxlen)
 }
 
 fn C.SDL_strcasecmp(str1 &char, str2 &char) int
-pub fn strcasecmp(str1 string, str2 string) int {
-	return C.SDL_strcasecmp(str1.str, str2.str)
+pub fn strcasecmp(str1 &char, str2 &char) int {
+	return C.SDL_strcasecmp(str1, str2)
 }
 
 fn C.SDL_strncasecmp(str1 &char, str2 &char, len usize) int
-pub fn strncasecmp(str1 string, str2 string, len usize) int {
-	return C.SDL_strncasecmp(str1.str, str2.str, len)
+pub fn strncasecmp(str1 &char, str2 &char, len usize) int {
+	return C.SDL_strncasecmp(str1, str2, len)
 }
 
 // Skipped:
@@ -380,8 +380,8 @@ extern DECLSPEC int SDLCALL SDL_sscanf(const char *text, SDL_SCANF_FORMAT_STRING
 */
 
 fn C.SDL_vsscanf(text &char, fmt &char, ap C.va_list) int
-pub fn vsscanf(text string, fmt string, ap C.va_list) int {
-	return C.SDL_vsscanf(text.str, fmt.str, ap)
+pub fn vsscanf(text &char, fmt &char, ap C.va_list) int {
+	return C.SDL_vsscanf(text, fmt, ap)
 }
 
 // Skipped:

--- a/surface.c.v
+++ b/surface.c.v
@@ -151,8 +151,8 @@ fn C.SDL_LoadBMP(file &char) &C.SDL_Surface
 // load_bmp loads a surface from a file.
 //
 // Convenience macro.
-pub fn load_bmp(path string) &Surface {
-	return C.SDL_LoadBMP(path.str)
+pub fn load_bmp(path &char) &Surface {
+	return C.SDL_LoadBMP(path)
 }
 
 fn C.SDL_SaveBMP_RW(surface &C.SDL_Surface, dst &C.SDL_RWops, freedst int) int
@@ -177,8 +177,8 @@ fn C.SDL_SaveBMP(surface &C.SDL_Surface, file &char)
 // save_bmp save a surface to a file.
 //
 // Convenience macro.
-pub fn save_bmp(surface &Surface, path string) {
-	C.SDL_SaveBMP(surface, path.str)
+pub fn save_bmp(surface &Surface, path &char) {
+	C.SDL_SaveBMP(surface, path)
 }
 
 fn C.SDL_SetSurfaceRLE(surface &C.SDL_Surface, flag int) int

--- a/system_android.c.v
+++ b/system_android.c.v
@@ -48,8 +48,8 @@ fn C.SDL_AndroidGetInternalStoragePath() &char
 //
 // This path is unique to your application and cannot be written to
 // by other applications.
-pub fn android_get_internal_storage_path() string {
-	return unsafe { cstring_to_vstring(C.SDL_AndroidGetInternalStoragePath()) }
+pub fn android_get_internal_storage_path() &char {
+	return C.SDL_AndroidGetInternalStoragePath()
 }
 
 fn C.SDL_AndroidGetExternalStorageState() int
@@ -69,6 +69,6 @@ fn C.SDL_AndroidGetExternalStoragePath() &char
 //
 // This path is unique to your application, but is public and can be
 // written to by other applications.
-pub fn android_get_external_storage_path() string {
-	return unsafe { cstring_to_vstring(C.SDL_AndroidGetExternalStoragePath()) }
+pub fn android_get_external_storage_path() &char {
+	return C.SDL_AndroidGetExternalStoragePath()
 }

--- a/thread.c.v
+++ b/thread.c.v
@@ -74,19 +74,19 @@ fn C.SDL_CreateThread(func ThreadFunction, name &char, data voidptr) &C.SDL_Thre
 // If a system imposes requirements, SDL will try to munge the string for
 //  it (truncate, etc), but the original string contents will be available
 //  from SDL_GetThreadName().
-pub fn create_thread(func ThreadFunction, name string, data voidptr) &Thread {
-	return C.SDL_CreateThread(func, name.str, data)
+pub fn create_thread(func ThreadFunction, name &char, data voidptr) &Thread {
+	return C.SDL_CreateThread(func, name, data)
 }
 
-fn C.SDL_GetThreadName(thrd &C.SDL_Thread) &char
+fn C.SDL_GetThreadName(thread &C.SDL_Thread) &char
 
 // get_thread_name gets the thread name, as it was specified in SDL_CreateThread().
 // This function returns a pointer to a UTF-8 string that names the
 // specified thread, or NULL if it doesn't have a name. This is internal
 // memory, not to be free()'d by the caller, and remains valid until the
 // specified thread is cleaned up by SDL_WaitThread().
-pub fn get_thread_name(thrd &Thread) string {
-	return unsafe { cstring_to_vstring(C.SDL_GetThreadName(thrd)) }
+pub fn get_thread_name(thread &Thread) &char {
+	return C.SDL_GetThreadName(thread)
 }
 
 fn C.SDL_ThreadID() C.SDL_threadID

--- a/ttf/ttf.c.v
+++ b/ttf/ttf.c.v
@@ -58,13 +58,13 @@ fn C.TTF_OpenFont(file &char, ptsize int) &C.TTF_Font
 // Some .fon fonts will have several sizes embedded in the file, so the
 // point size becomes the index of choosing which size.  If the value
 // is too high, the last indexed size will be the default.
-pub fn open_font(file string, ptsize int) &Font {
-	return C.TTF_OpenFont(file.str, ptsize)
+pub fn open_font(file &char, ptsize int) &Font {
+	return C.TTF_OpenFont(file, ptsize)
 }
 
 fn C.TTF_OpenFontIndex(file &char, ptsize int, index int) &C.TTF_Font
-pub fn open_font_index(file string, ptsize int, index int) &Font {
-	return C.TTF_OpenFontIndex(file.str, ptsize, index)
+pub fn open_font_index(file &char, ptsize int, index int) &Font {
+	return C.TTF_OpenFontIndex(file, ptsize, index)
 }
 
 fn C.TTF_OpenFontRW(src &C.SDL_RWops, freesrc int, ptsize int) &C.TTF_Font
@@ -183,13 +183,13 @@ pub fn font_face_is_fixed_width(font &Font) int {
 }
 
 fn C.TTF_FontFaceFamilyName(font &C.TTF_Font) &char
-pub fn font_face_family_name(font &Font) string {
-	return unsafe { cstring_to_vstring(C.TTF_FontFaceFamilyName(font)) }
+pub fn font_face_family_name(font &Font) &char {
+	return C.TTF_FontFaceFamilyName(font)
 }
 
 fn C.TTF_FontFaceStyleName(font &C.TTF_Font) &char
-pub fn font_face_style_name(font &Font) string {
-	return unsafe { cstring_to_vstring(C.TTF_FontFaceStyleName(font)) }
+pub fn font_face_style_name(font &Font) &char {
+	return C.TTF_FontFaceStyleName(font)
 }
 
 fn C.TTF_GlyphIsProvided(font &C.TTF_Font, ch u16) int
@@ -221,11 +221,8 @@ pub fn size_utf8(font &Font, text &char, w &int, h &int) int {
 }
 
 fn C.TTF_SizeUNICODE(font &Font, text &u16, w &int, h &int) int
-pub fn size_unicode(font &C.TTF_Font, text string, w &int, h &int) int {
-	wt := text.to_wide()
-	s := C.TTF_SizeUNICODE(font, wt, w, h)
-	unsafe { free(wt) }
-	return s
+pub fn size_unicode(font &C.TTF_Font, text &u16, w &int, h &int) int {
+	return C.TTF_SizeUNICODE(font, text, w, h)
 }
 
 fn C.TTF_RenderText_Solid(font &C.TTF_Font, text &char, fg C.SDL_Color) &C.SDL_Surface

--- a/version.c.v
+++ b/version.c.v
@@ -51,10 +51,8 @@ fn C.SDL_VERSION(ver &C.SDL_version)
 //
 // See also: SDL_version
 // See also: SDL_GetVersion
-pub fn version() string {
-	ver := Version{}
+pub fn version(mut ver Version) {
 	C.SDL_VERSION(&ver)
-	return ver.str()
 }
 
 // This macro turns the version numbers into a numeric value:
@@ -96,10 +94,8 @@ printf("But we linked against SDL version %d.%d.%d.\n", linked.major, linked.min
 // This function may be called safely at any time, even before SDL_Init().
 //
 // See also: SDL_VERSION
-pub fn get_version() string {
-	ver := Version{}
+pub fn get_version(mut ver Version) {
 	C.SDL_GetVersion(&ver)
-	return ver.str()
 }
 
 fn C.SDL_GetRevision() &char
@@ -109,8 +105,8 @@ fn C.SDL_GetRevision() &char
 // Returns an arbitrary string (a hash value) uniquely identifying the
 // exact revision of the SDL library in use, and is only useful in comparing
 // against other revisions. It is NOT an incrementing number.
-pub fn get_revision() string {
-	return unsafe { cstring_to_vstring(C.SDL_GetRevision()) }
+pub fn get_revision() &char {
+	return C.SDL_GetRevision()
 }
 
 fn C.SDL_GetRevisionNumber() int

--- a/video.c.v
+++ b/video.c.v
@@ -264,8 +264,8 @@ fn C.SDL_VideoInit(driver_name &char) int
 // and pixel formats, but does not initialize a window or graphics mode.
 //
 // See also: SDL_VideoQuit()
-pub fn video_init(driver_name string) int {
-	return C.SDL_VideoInit(driver_name.str)
+pub fn video_init(driver_name &char) int {
+	return C.SDL_VideoInit(driver_name)
 }
 
 fn C.SDL_VideoQuit()
@@ -510,8 +510,8 @@ fn C.SDL_CreateWindow(title &char, x int, y int, w int, h int, flags u32) &C.SDL
 // See also: SDL_DestroyWindow()
 // See also: SDL_GL_LoadLibrary()
 // See also: SDL_Vulkan_LoadLibrary()
-pub fn create_window(title string, x int, y int, w int, h int, flags u32) &Window {
-	return C.SDL_CreateWindow(title.str, x, y, w, h, flags)
+pub fn create_window(title &char, x int, y int, w int, h int, flags u32) &Window {
+	return C.SDL_CreateWindow(title, x, y, w, h, flags)
 }
 
 fn C.SDL_CreateWindowFrom(data voidptr) &C.SDL_Window
@@ -553,8 +553,8 @@ fn C.SDL_SetWindowTitle(window &C.SDL_Window, title &char)
 // set_window_title sets the title of a window, in UTF-8 format.
 //
 // See also: SDL_GetWindowTitle()
-pub fn set_window_title(window &Window, title string) {
-	C.SDL_SetWindowTitle(window, title.str)
+pub fn set_window_title(window &Window, title &char) {
+	C.SDL_SetWindowTitle(window, title)
 }
 
 fn C.SDL_GetWindowTitle(window &C.SDL_Window) &char
@@ -589,8 +589,8 @@ fn C.SDL_SetWindowData(window &C.SDL_Window, name &char, userdata voidptr) voidp
 // NOTE The name is case-sensitive.
 //
 // See also: SDL_GetWindowData()
-pub fn set_window_data(window &Window, name string, userdata voidptr) voidptr {
-	return C.SDL_SetWindowData(window, name.str, userdata)
+pub fn set_window_data(window &Window, name &char, userdata voidptr) voidptr {
+	return C.SDL_SetWindowData(window, name, userdata)
 }
 
 fn C.SDL_GetWindowData(window &C.SDL_Window, name &char) voidptr
@@ -1165,8 +1165,8 @@ fn C.SDL_GL_LoadLibrary(path &char) int
 //
 // See also: SDL_GL_GetProcAddress()
 // See also: SDL_GL_UnloadLibrary()
-pub fn gl_load_library(path string) int {
-	return C.SDL_GL_LoadLibrary(path.str)
+pub fn gl_load_library(path &char) int {
+	return C.SDL_GL_LoadLibrary(path)
 }
 
 fn C.SDL_GL_GetProcAddress(proc &char) voidptr

--- a/vulkan/vulkan.c.v
+++ b/vulkan/vulkan.c.v
@@ -67,8 +67,8 @@ fn C.SDL_Vulkan_LoadLibrary(path &char) int
 //
 // See also: SDL_Vulkan_GetVkGetInstanceProcAddr()
 // See also: SDL_Vulkan_UnloadLibrary()
-pub fn vulkan_load_library(path string) int {
-	return C.SDL_Vulkan_LoadLibrary(path.str)
+pub fn vulkan_load_library(path &char) int {
+	return C.SDL_Vulkan_LoadLibrary(path)
 }
 
 fn C.SDL_Vulkan_GetVkGetInstanceProcAddr() voidptr


### PR DESCRIPTION
This PR makes sure that all call signatures that used `string` before now uses `&char` as used in the original SDL call API.
This is to make sure that translating to `sdl` matches the C API as close as possible for people doing ports. It's planned to generate a `v` sub-module that will make writing SDL based apps in V, from scratch, easier. This module will make use of C <-> V string conversions and introduce "V-isms" to make life easier for V programmers.