### PR TITLE
sdl: make union fields pub mut where applicable

### DIFF
--- a/haptic.c.v
+++ b/haptic.c.v
@@ -237,7 +237,7 @@ direction.dir[0] = 9000; // Since we only have two axes we don't need more param
 
 [typedef]
 struct C.SDL_HapticDirection {
-pub:
+pub mut:
 	@type byte // The type of encoding
 	dir   [3]int
 }
@@ -255,7 +255,7 @@ pub type HapticDirection = C.SDL_HapticDirection
 // See also: SDL_HapticEffect
 [typedef]
 struct C.SDL_HapticConstant {
-pub:
+pub mut:
 	@type         u16 // ::SDL_HAPTIC_CONSTANT
 	direction     HapticDirection // Direction of the effect.
 	length        u32 // Duration of the effect.
@@ -331,7 +331,7 @@ pub type HapticConstant = C.SDL_HapticConstant
 
 [typedef]
 struct C.SDL_HapticPeriodic {
-pub:
+pub mut:
 	@type         u16 // ::SDL_HAPTIC_SINE, ::SDL_HAPTIC_LEFTRIGHT, ::SDL_HAPTIC_TRIANGLE, ::SDL_HAPTIC_SAWTOOTHUP or ::SDL_HAPTIC_SAWTOOTHDOWN
 	direction     HapticDirection // Direction of the effect.
 	length        u32 // Duration of the effect.
@@ -374,7 +374,7 @@ pub type HapticPeriodic = C.SDL_HapticPeriodic
 // See also: SDL_HapticEffect
 [typedef]
 struct C.SDL_HapticCondition {
-pub:
+pub mut:
 	@type       u16 // ::SDL_HAPTIC_SPRING, ::SDL_HAPTIC_DAMPER,                                  ::SDL_HAPTIC_INERTIA or ::SDL_HAPTIC_FRICTION
 	direction   HapticDirection // Direction of the effect - Not used ATM.
 	length      u32    // Duration of the effect.
@@ -404,7 +404,7 @@ pub type HapticCondition = C.SDL_HapticCondition
 // See also: SDL_HapticEffect
 [typedef]
 struct C.SDL_HapticRamp {
-pub:
+pub mut:
 	@type         u16 // ::SDL_HAPTIC_RAMP
 	direction     HapticDirection // Direction of the effect.
 	length        u32 // Duration of the effect.
@@ -433,7 +433,7 @@ pub type HapticRamp = C.SDL_HapticRamp
 // See also: SDL_HapticEffect
 [typedef]
 struct C.SDL_HapticLeftRight {
-pub:
+pub mut:
 	@type           u16 // ::SDL_HAPTIC_LEFTRIGHT
 	length          u32 // Duration of the effect.
 	large_magnitude u16 // Control of the large controller motor.
@@ -457,7 +457,7 @@ pub type HapticLeftRight = C.SDL_HapticLeftRight
 // See also: SDL_HapticEffect
 [typedef]
 struct C.SDL_HapticCustom {
-pub:
+pub mut:
 	@type         u16 // ::SDL_HAPTIC_CUSTOM
 	direction     HapticDirection // Direction of the effect.
 	length        u32  // Duration of the effect.
@@ -551,7 +551,7 @@ Uint16 fade_level;    // Level at the end of the fade.
 
 [typedef]
 union C.SDL_HapticEffect {
-pub:
+pub mut:
 	// Common for all force feedback effects
 	@type     u16 // Effect type.
 	constant  HapticConstant  // Constant effect.

--- a/shape.c.v
+++ b/shape.c.v
@@ -68,7 +68,7 @@ pub fn shapemodealpha(mode WindowShapeModeFlag) bool {
 // WindowShapeParams is C.SDL_WindowShapeParams
 [typedef]
 union C.SDL_WindowShapeParams {
-pub:
+pub mut:
 	binarizationCutoff byte // A cutoff alpha value for binarization of the window shape's alpha channel.
 	colorKey           Color
 }


### PR DESCRIPTION
This PR prevents a cgen error in situations where you want to initialize
a union in several steps:
`cgen error: union must not have more than 1 initializer`
(The solution is to initialize the union by setting fields one by one, but wasn't possible before this PR)

Attempted:
```v
// Create the effect
direction := HapticDirection {
  ...
}
periodic := HapticPeriodic{
	direction: direction
	period: 1000
	magnitude: 20000
	... etc.
}

effect := sdl.HapticEffect{
	@type: u16(sdl.haptic_sine)
	periodic: periodic
}
```
Results in `cgen error: union must not have more than 1 initializer`


After PR the initialization is now possible:
```v
// Create the effect
mut effect := sdl.HapticEffect{}
unsafe {
	vmemset( &effect, 0, int(sizeof(effect)) ) // 0 is safe default
}

effect.@type = u16(sdl.haptic_sine)
effect.periodic.direction.@type = byte(sdl.haptic_polar) // Polar coordinates
effect.periodic.direction.dir[0] = 18000 // Force comes from south
effect.periodic.period = 1000 // 1000 ms
effect.periodic.magnitude = 20000 // 20000/32767 strength
effect.periodic.length = 5000 // 5 seconds long
effect.periodic.attack_length = 1000 // Takes 1 second to get max strength
effect.periodic.fade_length = 1000 // Takes 1 second to fade away

// Upload the effect
effect_id := sdl.haptic_new_effect( haptic, &effect )

// Test the effect
sdl.haptic_run_effect( haptic, effect_id, 1 )
sdl.delay( 5000) // Wait for the effect to finish

// We destroy the effect, although closing the device also does this
sdl.haptic_destroy_effect( haptic, effect_id )
```