### PR TITLE
sdl: makes compile with tcc

### DIFF
--- a/c/sdl.c.v
+++ b/c/sdl.c.v
@@ -8,6 +8,11 @@ pub const used_import = 1
 $if !windows {
 	#pkgconfig --cflags --libs sdl2
 	#flag -lSDL2_ttf -lSDL2_mixer -lSDL2_image
+} $else {
+	$if tinyc {
+		#define _STDINT_H_
+		#flag -L @VMODROOT/thirdparty
+	}
 }
 
 #flag -DSDL_DISABLE_IMMINTRIN_H

--- a/windows_install_dependencies.vsh
+++ b/windows_install_dependencies.vsh
@@ -34,4 +34,11 @@ fn main() {
 			return
 		}
 	}
+	// Finally, create the SDL2main.def stub file for tcc
+	stub_file := os.real_path(os.join_path(destination, 'SDL2main.def'))
+	mut f := os.create(stub_file) or {
+		println('Unable to create $stub_file')
+		return
+	}
+	f.close()
 }


### PR DESCRIPTION
The required stub file, SDL2main.def, is created in the root directory of the module.
To be honest, I don't like this. 
It should be in the ...\sdl\thirdparty\SDL2-VERSION\lib directory, but I don't see how this can be easily changed since no versioning system is currently used, right?
If you have an idea how such a versioning mechanism would also be accessible from V to set the required flag and use the windows_install_dependencies.vsh script to create the stub file, let me know.