### PR TITLE
general 2.0.10: add unsafe blocks around enum and int conversions (#437)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore binary files
+*.so

--- a/blendmode.c.v
+++ b/blendmode.c.v
@@ -59,7 +59,10 @@ fn C.SDL_ComposeCustomBlendMode(src_color_factor C.SDL_BlendFactor, dst_color_fa
 // and
 // dstA = dstA * dstAlphaFactor alphaOperation srcA * srcAlphaFactor
 pub fn compose_custom_blend_mode(src_color_factor BlendFactor, dst_color_factor BlendFactor, color_operation BlendOperation, src_alpha_factor BlendFactor, dst_alpha_factor BlendFactor, alpha_operation BlendOperation) BlendMode {
-	return BlendMode(int(C.SDL_ComposeCustomBlendMode(C.SDL_BlendFactor(src_color_factor),
-		C.SDL_BlendFactor(dst_color_factor), C.SDL_BlendOperation(color_operation), C.SDL_BlendFactor(src_alpha_factor),
-		C.SDL_BlendFactor(dst_alpha_factor), C.SDL_BlendOperation(alpha_operation))))
+	return unsafe {
+		BlendMode(int(C.SDL_ComposeCustomBlendMode(C.SDL_BlendFactor(src_color_factor),
+			C.SDL_BlendFactor(dst_color_factor), C.SDL_BlendOperation(color_operation),
+			C.SDL_BlendFactor(src_alpha_factor), C.SDL_BlendFactor(dst_alpha_factor),
+			C.SDL_BlendOperation(alpha_operation))))
+	}
 }

--- a/joystick.c.v
+++ b/joystick.c.v
@@ -150,7 +150,7 @@ fn C.SDL_JoystickGetDeviceType(device_index int) C.SDL_JoystickType
 // joystick_get_device_type gets the type of a joystick, if available.
 // This can be called before any joysticks are opened.
 pub fn joystick_get_device_type(device_index int) JoystickType {
-	return JoystickType(int(C.SDL_JoystickGetDeviceType(device_index)))
+	return unsafe { JoystickType(int(C.SDL_JoystickGetDeviceType(device_index))) }
 }
 
 fn C.SDL_JoystickGetDeviceInstanceID(device_index int) C.SDL_JoystickID
@@ -159,7 +159,7 @@ fn C.SDL_JoystickGetDeviceInstanceID(device_index int) C.SDL_JoystickID
 // This can be called before any joysticks are opened.
 // If the index is out of range, this function will return -1.
 pub fn joystick_get_device_instance_id(device_index int) JoystickID {
-	return int(C.SDL_JoystickGetDeviceInstanceID(device_index))
+	return unsafe { int(C.SDL_JoystickGetDeviceInstanceID(device_index)) }
 }
 
 fn C.SDL_JoystickOpen(device_index int) &C.SDL_Joystick
@@ -234,7 +234,7 @@ fn C.SDL_JoystickGetType(joystick &C.SDL_Joystick) C.SDL_JoystickType
 
 // joystick_get_type gets the type of an opened joystick.
 pub fn joystick_get_type(joystick &Joystick) JoystickType {
-	return JoystickType(int(C.SDL_JoystickGetType(joystick)))
+	return unsafe { JoystickType(int(C.SDL_JoystickGetType(joystick))) }
 }
 
 fn C.SDL_JoystickGetGUIDString(guid C.SDL_JoystickGUID, psz_guid &char, cb_guid int)
@@ -411,5 +411,5 @@ fn C.SDL_JoystickCurrentPowerLevel(joystick &C.SDL_Joystick) C.SDL_JoystickPower
 
 // joystick_current_power_level returns the battery level of this joystick
 pub fn joystick_current_power_level(joystick &Joystick) JoystickPowerLevel {
-	return JoystickPowerLevel(int(C.SDL_JoystickCurrentPowerLevel(joystick)))
+	return unsafe { JoystickPowerLevel(int(C.SDL_JoystickCurrentPowerLevel(joystick))) }
 }

--- a/keyboard.c.v
+++ b/keyboard.c.v
@@ -54,7 +54,7 @@ fn C.SDL_GetModState() C.SDL_Keymod
 
 // get_mod_state gets the current key modifier state for the keyboard.
 pub fn get_mod_state() Keymod {
-	return Keymod(int(C.SDL_GetModState()))
+	return unsafe { Keymod(int(C.SDL_GetModState())) }
 }
 
 fn C.SDL_SetModState(modstate C.SDL_Keymod)
@@ -87,7 +87,7 @@ fn C.SDL_GetScancodeFromKey(key C.SDL_Keycode) C.SDL_Scancode
 //
 // See also: SDL_GetScancodeName()
 pub fn get_scancode_from_key(key Keycode) Scancode {
-	return Scancode(int(C.SDL_GetScancodeFromKey(C.SDL_Keycode(key))))
+	return unsafe { Scancode(int(C.SDL_GetScancodeFromKey(C.SDL_Keycode(key)))) }
 }
 
 fn C.SDL_GetScancodeName(scancode C.SDL_Scancode) &char
@@ -111,7 +111,7 @@ fn C.SDL_GetScancodeFromName(name &char) C.SDL_Scancode
 //
 // See also: SDL_Scancode
 pub fn get_scancode_from_name(name &char) Scancode {
-	return Scancode(int(C.SDL_GetScancodeFromName(name)))
+	return unsafe { Scancode(int(C.SDL_GetScancodeFromName(name))) }
 }
 
 fn C.SDL_GetKeyName(key C.SDL_Keycode) &char

--- a/log.c.v
+++ b/log.c.v
@@ -81,7 +81,7 @@ fn C.SDL_LogGetPriority(category int) C.SDL_LogPriority
 
 // log_get_priority gets the priority of a particular log category
 pub fn log_get_priority(category int) LogPriority {
-	return LogPriority(int(C.SDL_LogGetPriority(category)))
+	return unsafe { LogPriority(int(C.SDL_LogGetPriority(category))) }
 }
 
 fn C.SDL_LogResetPriorities()

--- a/pixels.c.v
+++ b/pixels.c.v
@@ -203,7 +203,7 @@ fn C.SDL_MasksToPixelFormatEnum(bpp int, rmask u32, gmask u32, bmask u32, amask 
 //
 // See also: SDL_PixelFormatEnumToMasks()
 pub fn masks_to_pixel_format_enum(bpp int, rmask u32, gmask u32, bmask u32, amask u32) Format {
-	return Format(C.SDL_MasksToPixelFormatEnum(bpp, rmask, gmask, bmask, amask))
+	return unsafe { Format(C.SDL_MasksToPixelFormatEnum(bpp, rmask, gmask, bmask, amask)) }
 }
 
 fn C.SDL_AllocFormat(pixel_format Format) &C.SDL_PixelFormat

--- a/surface.c.v
+++ b/surface.c.v
@@ -522,7 +522,7 @@ fn C.SDL_GetYUVConversionMode() C.SDL_YUV_CONVERSION_MODE
 
 // get_yuv_conversion_mode gets the YUV conversion mode
 pub fn get_yuv_conversion_mode() YUVConversionMode {
-	return YUVConversionMode(int(C.SDL_GetYUVConversionMode()))
+	return unsafe { YUVConversionMode(int(C.SDL_GetYUVConversionMode())) }
 }
 
 fn C.SDL_GetYUVConversionModeForResolution(width int, height int) C.SDL_YUV_CONVERSION_MODE
@@ -530,5 +530,7 @@ fn C.SDL_GetYUVConversionModeForResolution(width int, height int) C.SDL_YUV_CONV
 // get_yuv_conversion_mode_for_resolution gets the YUV conversion mode, returning the correct mode for the resolution when
 // the current conversion mode is SDL_YUV_CONVERSION_AUTOMATIC
 pub fn get_yuv_conversion_mode_for_resolution(width int, height int) YUVConversionMode {
-	return YUVConversionMode(int(C.SDL_GetYUVConversionModeForResolution(width, height)))
+	return unsafe {
+		YUVConversionMode(int(C.SDL_GetYUVConversionModeForResolution(width, height)))
+	}
 }

--- a/touch.c.v
+++ b/touch.c.v
@@ -59,7 +59,7 @@ fn C.SDL_GetTouchDeviceType(touch_id TouchID) C.SDL_TouchDeviceType
 
 // get_touch_device_type gets the type of the given touch device.
 pub fn get_touch_device_type(touch_id TouchID) TouchDeviceType {
-	return TouchDeviceType(int(C.SDL_GetTouchDeviceType(touch_id)))
+	return unsafe { TouchDeviceType(int(C.SDL_GetTouchDeviceType(touch_id))) }
 }
 
 fn C.SDL_GetNumTouchFingers(touch_id TouchID) int


### PR DESCRIPTION
Cherry-picked commit https://github.com/vlang/sdl/commit/f222dc38e02d7a1950cc7de5f2f9a185b688ec19 on master to 2.0.10