### PR TITLE
general 2.0.22: add unsafe blocks around enum and int conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore binary files
+*.so

--- a/blendmode.c.v
+++ b/blendmode.c.v
@@ -138,7 +138,10 @@ fn C.SDL_ComposeCustomBlendMode(src_color_factor C.SDL_BlendFactor, dst_color_fa
 // See also: SDL_SetTextureBlendMode
 // See also: SDL_GetTextureBlendMode
 pub fn compose_custom_blend_mode(src_color_factor BlendFactor, dst_color_factor BlendFactor, color_operation BlendOperation, src_alpha_factor BlendFactor, dst_alpha_factor BlendFactor, alpha_operation BlendOperation) BlendMode {
-	return BlendMode(int(C.SDL_ComposeCustomBlendMode(C.SDL_BlendFactor(src_color_factor),
-		C.SDL_BlendFactor(dst_color_factor), C.SDL_BlendOperation(color_operation), C.SDL_BlendFactor(src_alpha_factor),
-		C.SDL_BlendFactor(dst_alpha_factor), C.SDL_BlendOperation(alpha_operation))))
+	return unsafe {
+		BlendMode(int(C.SDL_ComposeCustomBlendMode(C.SDL_BlendFactor(src_color_factor),
+			C.SDL_BlendFactor(dst_color_factor), C.SDL_BlendOperation(color_operation),
+			C.SDL_BlendFactor(src_alpha_factor), C.SDL_BlendFactor(dst_alpha_factor),
+			C.SDL_BlendOperation(alpha_operation))))
+	}
 }

--- a/gamecontroller.c.v
+++ b/gamecontroller.c.v
@@ -290,7 +290,7 @@ fn C.SDL_GameControllerTypeForIndex(joystick_index int) C.SDL_GameControllerType
 //
 // NOTE This function is available since SDL 2.0.12.
 pub fn game_controller_type_for_index(joystick_index int) GameControllerType {
-	return GameControllerType(int(C.SDL_GameControllerTypeForIndex(joystick_index)))
+	return unsafe { GameControllerType(int(C.SDL_GameControllerTypeForIndex(joystick_index))) }
 }
 
 fn C.SDL_GameControllerMappingForDeviceIndex(joystick_index int) &char
@@ -399,7 +399,7 @@ fn C.SDL_GameControllerGetType(gamecontroller &C.SDL_GameController) C.SDL_GameC
 //
 // NOTE This function is available since SDL 2.0.12.
 pub fn game_controller_get_type(gamecontroller &GameController) GameControllerType {
-	return GameControllerType(int(C.SDL_GameControllerGetType(gamecontroller)))
+	return unsafe { GameControllerType(int(C.SDL_GameControllerGetType(gamecontroller))) }
 }
 
 fn C.SDL_GameControllerGetPlayerIndex(gamecontroller &C.SDL_GameController) int

--- a/joystick.c.v
+++ b/joystick.c.v
@@ -230,7 +230,7 @@ fn C.SDL_JoystickGetDeviceType(device_index int) C.SDL_JoystickType
 //
 // NOTE This function is available since SDL 2.0.6.
 pub fn joystick_get_device_type(device_index int) JoystickType {
-	return JoystickType(int(C.SDL_JoystickGetDeviceType(device_index)))
+	return unsafe { JoystickType(int(C.SDL_JoystickGetDeviceType(device_index))) }
 }
 
 fn C.SDL_JoystickGetDeviceInstanceID(device_index int) C.SDL_JoystickID
@@ -247,7 +247,7 @@ fn C.SDL_JoystickGetDeviceInstanceID(device_index int) C.SDL_JoystickID
 //
 // NOTE This function is available since SDL 2.0.6.
 pub fn joystick_get_device_instance_id(device_index int) JoystickID {
-	return int(C.SDL_JoystickGetDeviceInstanceID(device_index))
+	return unsafe { int(C.SDL_JoystickGetDeviceInstanceID(device_index)) }
 }
 
 fn C.SDL_JoystickOpen(device_index int) &C.SDL_Joystick
@@ -524,7 +524,7 @@ fn C.SDL_JoystickGetType(joystick &C.SDL_Joystick) C.SDL_JoystickType
 //
 // NOTE This function is available since SDL 2.0.6.
 pub fn joystick_get_type(joystick &Joystick) JoystickType {
-	return JoystickType(int(C.SDL_JoystickGetType(joystick)))
+	return unsafe { JoystickType(int(C.SDL_JoystickGetType(joystick))) }
 }
 
 fn C.SDL_JoystickGetGUIDString(guid C.SDL_JoystickGUID, psz_guid &char, cb_guid int)
@@ -967,5 +967,5 @@ fn C.SDL_JoystickCurrentPowerLevel(joystick &C.SDL_Joystick) C.SDL_JoystickPower
 //
 // NOTE This function is available since SDL 2.0.4.
 pub fn joystick_current_power_level(joystick &Joystick) JoystickPowerLevel {
-	return JoystickPowerLevel(int(C.SDL_JoystickCurrentPowerLevel(joystick)))
+	return unsafe { JoystickPowerLevel(int(C.SDL_JoystickCurrentPowerLevel(joystick))) }
 }

--- a/keyboard.c.v
+++ b/keyboard.c.v
@@ -77,7 +77,7 @@ fn C.SDL_GetModState() C.SDL_Keymod
 // See also: SDL_GetKeyboardState
 // See also: SDL_SetModState
 pub fn get_mod_state() Keymod {
-	return Keymod(int(C.SDL_GetModState()))
+	return unsafe { Keymod(int(C.SDL_GetModState())) }
 }
 
 fn C.SDL_SetModState(modstate C.SDL_Keymod)
@@ -134,7 +134,7 @@ fn C.SDL_GetScancodeFromKey(key C.SDL_Keycode) C.SDL_Scancode
 // See also: SDL_GetKeyFromScancode
 // See also: SDL_GetScancodeName
 pub fn get_scancode_from_key(key Keycode) Scancode {
-	return Scancode(int(C.SDL_GetScancodeFromKey(C.SDL_Keycode(key))))
+	return unsafe { Scancode(int(C.SDL_GetScancodeFromKey(C.SDL_Keycode(key)))) }
 }
 
 fn C.SDL_GetScancodeName(scancode C.SDL_Scancode) &char
@@ -178,7 +178,7 @@ fn C.SDL_GetScancodeFromName(name &char) C.SDL_Scancode
 // See also: SDL_GetScancodeFromKey
 // See also: SDL_GetScancodeName
 pub fn get_scancode_from_name(name &char) Scancode {
-	return Scancode(int(C.SDL_GetScancodeFromName(name)))
+	return unsafe { Scancode(int(C.SDL_GetScancodeFromName(name))) }
 }
 
 fn C.SDL_GetKeyName(key C.SDL_Keycode) &char

--- a/log.c.v
+++ b/log.c.v
@@ -102,7 +102,7 @@ fn C.SDL_LogGetPriority(category int) C.SDL_LogPriority
 //
 // See also: SDL_LogSetPriority
 pub fn log_get_priority(category int) LogPriority {
-	return LogPriority(int(C.SDL_LogGetPriority(category)))
+	return unsafe { LogPriority(int(C.SDL_LogGetPriority(category))) }
 }
 
 fn C.SDL_LogResetPriorities()

--- a/pixels.c.v
+++ b/pixels.c.v
@@ -239,7 +239,7 @@ fn C.SDL_MasksToPixelFormatEnum(bpp int, rmask u32, gmask u32, bmask u32, amask 
 //
 // See also: SDL_PixelFormatEnumToMasks
 pub fn masks_to_pixel_format_enum(bpp int, rmask u32, gmask u32, bmask u32, amask u32) Format {
-	return Format(C.SDL_MasksToPixelFormatEnum(bpp, rmask, gmask, bmask, amask))
+	return unsafe { Format(C.SDL_MasksToPixelFormatEnum(bpp, rmask, gmask, bmask, amask)) }
 }
 
 fn C.SDL_AllocFormat(pixel_format Format) &C.SDL_PixelFormat

--- a/surface.c.v
+++ b/surface.c.v
@@ -945,7 +945,7 @@ fn C.SDL_GetYUVConversionMode() C.SDL_YUV_CONVERSION_MODE
 //
 // NOTE This function is available since SDL 2.0.8.
 pub fn get_yuv_conversion_mode() YUVConversionMode {
-	return YUVConversionMode(int(C.SDL_GetYUVConversionMode()))
+	return unsafe { YUVConversionMode(int(C.SDL_GetYUVConversionMode())) }
 }
 
 fn C.SDL_GetYUVConversionModeForResolution(width int, height int) C.SDL_YUV_CONVERSION_MODE
@@ -955,5 +955,7 @@ fn C.SDL_GetYUVConversionModeForResolution(width int, height int) C.SDL_YUV_CONV
 //
 // NOTE This function is available since SDL 2.0.8.
 pub fn get_yuv_conversion_mode_for_resolution(width int, height int) YUVConversionMode {
-	return YUVConversionMode(int(C.SDL_GetYUVConversionModeForResolution(width, height)))
+	return unsafe {
+		YUVConversionMode(int(C.SDL_GetYUVConversionModeForResolution(width, height)))
+	}
 }

--- a/touch.c.v
+++ b/touch.c.v
@@ -92,7 +92,7 @@ fn C.SDL_GetTouchDeviceType(touch_id TouchID) C.SDL_TouchDeviceType
 //
 // NOTE This function is available since SDL 2.0.10.
 pub fn get_touch_device_type(touch_id TouchID) TouchDeviceType {
-	return TouchDeviceType(int(C.SDL_GetTouchDeviceType(touch_id)))
+	return unsafe { TouchDeviceType(int(C.SDL_GetTouchDeviceType(touch_id))) }
 }
 
 fn C.SDL_GetNumTouchFingers(touch_id TouchID) int


### PR DESCRIPTION
Cherry-picked commit https://github.com/vlang/sdl/commit/f222dc38e02d7a1950cc7de5f2f9a185b688ec19 on master and https://github.com/vlang/sdl/commit/d97dc0ed3d1f1d9970c9cf812a599c8595b64e62 edits to 2.24.0

It's still causing a Cgen error for some reason with the https://github.com/vlang/v/pull/15932 Pull Request.

Update:

If the CI passes, I think it's okay.