### PR TITLE
all: add comptime sdl_no_compile_flags option

### DIFF
--- a/c/sdl.c.v
+++ b/c/sdl.c.v
@@ -6,10 +6,15 @@ module c
 pub const used_import = 1
 
 $if !windows {
-	// SDL libs are loaded dynamically in Java on Android
+	// SDL libs are loaded dynamically from Java on Android
 	$if !android || termux {
-		#pkgconfig --cflags --libs sdl2
-		#flag -lSDL2_ttf -lSDL2_mixer -lSDL2_image
+		// sdl_no_compile_flags allow users to provide
+		// custom flags (e.g. via CFLAGS/LDFLAGS) for the compiler.
+		// This is especially useful when building/linking against a
+		// custom compiled version of the libs on *nix.
+		$if !sdl_no_compile_flags ? {
+			#pkgconfig --cflags --libs sdl2
+		}
 	}
 } $else {
 	$if tinyc {

--- a/image/c.c.v
+++ b/image/c.c.v
@@ -1,6 +1,17 @@
 module image
 
-#flag linux -lSDL2_image
+$if !windows {
+	// SDL libs are loaded dynamically from Java on Android
+	$if !android || termux {
+		// sdl_no_compile_flags allow users to provide
+		// custom flags (e.g. via CFLAGS/LDFLAGS) for the compiler.
+		// This is especially useful when building/linking against a
+		// custom compiled version of the libs on *nix.
+		$if !sdl_no_compile_flags ? {
+			#flag -lSDL2_image
+		}
+	}
+}
 
 $if x64 {
 	#flag windows -L @VMODROOT/thirdparty/SDL2_image-2.0.3/lib/x64

--- a/mixer/c.c.v
+++ b/mixer/c.c.v
@@ -3,6 +3,19 @@
 // that can be found in the LICENSE file.
 module mixer
 
+$if !windows {
+	// SDL libs are loaded dynamically from Java on Android
+	$if !android || termux {
+		// sdl_no_compile_flags allow users to provide
+		// custom flags (e.g. via CFLAGS/LDFLAGS) for the compiler.
+		// This is especially useful when building/linking against a
+		// custom compiled version of the libs on *nix.
+		$if !sdl_no_compile_flags ? {
+			#flag -lSDL2_mixer
+		}
+	}
+}
+
 $if x64 {
 	#flag windows -L @VMODROOT/thirdparty/SDL2_mixer-2.0.2/lib/x64
 } $else {

--- a/ttf/c.c.v
+++ b/ttf/c.c.v
@@ -3,6 +3,19 @@
 // that can be found in the LICENSE file.
 module ttf
 
+$if !windows {
+	// SDL libs are loaded dynamically from Java on Android
+	$if !android || termux {
+		// sdl_no_compile_flags allow users to provide
+		// custom flags (e.g. via CFLAGS/LDFLAGS) for the compiler.
+		// This is especially useful when building/linking against a
+		// custom compiled version of the libs on *nix.
+		$if !sdl_no_compile_flags ? {
+			#flag -lSDL2_ttf
+		}
+	}
+}
+
 $if x64 {
 	#flag windows -L @VMODROOT/thirdparty/SDL2_ttf-2.0.14/lib/x64
 } $else {


### PR DESCRIPTION
This PR adds an escape hatch for compiling SDL2 with custom flags.

Before, the output of `pkgconfig` could interfere with the compile process in such a way that compilation would fail.
In combination with vlang/v#15977 this PR allows for more flexibility when building SDL2.

For reference, see initial discussion/conclusion on Discord:
* https://discord.com/channels/592103645835821068/592320321995014154/1024608412136390706
* https://discord.com/channels/592103645835821068/592320321995014154/1027526771043741706