### PR TITLE
thread: change variable name before it become unallowed

### DIFF
--- a/thread.c.v
+++ b/thread.c.v
@@ -78,15 +78,15 @@ pub fn create_thread(func ThreadFunction, const_name &char, data voidptr) &Threa
 	return C.SDL_CreateThread(func, const_name, data)
 }
 
-fn C.SDL_GetThreadName(thread &C.SDL_Thread) &char
+fn C.SDL_GetThreadName(pthread &C.SDL_Thread) &char
 
 // get_thread_name gets the thread name, as it was specified in SDL_CreateThread().
 // This function returns a pointer to a UTF-8 string that names the
 // specified thread, or NULL if it doesn't have a name. This is internal
 // memory, not to be free()'d by the caller, and remains valid until the
 // specified thread is cleaned up by SDL_WaitThread().
-pub fn get_thread_name(thread &Thread) &char {
-	return C.SDL_GetThreadName(thread)
+pub fn get_thread_name(pthread &Thread) &char {
+	return C.SDL_GetThreadName(pthread)
 }
 
 fn C.SDL_ThreadID() C.SDL_threadID


### PR DESCRIPTION
'thread' should not be used to name a variable as it is a reserved keyword.

It can actually be used, I'm changing their names now to prevent errors the day it will be patched.

<!--

Please title your PR as follows: `time: fix foo bar`.
Always start with the thing you are fixing, then describe the fix.
Don't use past tense (e.g. "fixed foo bar").

Explain what your PR does and why.

If you are adding a new function, please document it and add tests:

```
// foo does foo and bar
fn foo() {

// file_test.v
fn test_foo() {
    assert foo() == ...
    ...
}
```

If you are fixing a bug, please add a test that covers it.

Before submitting a PR, please test that the examples compile.

Applying labels to PRs is not needed.

Thanks a lot for your contribution!

-->
