### PR TITLE
memory: fix `C.fprintf` output by passing `mem` argument

### DIFF
--- a/c/memory.c.v
+++ b/c/memory.c.v
@@ -30,7 +30,7 @@ fn cb_realloc_func(mem voidptr, size usize) voidptr {
 
 fn cb_free_func(mem voidptr) {
 	$if trace_sdl_memory ? {
-		C.fprintf(C.stderr, c'>> sdl.c.cb_free_func | mem: %p\n')
+		C.fprintf(C.stderr, c'>> sdl.c.cb_free_func | mem: %p\n', mem)
 	}
 	unsafe { free(mem) }
 }


### PR DESCRIPTION
The CI will probably fail at `vfmt`  checks - these will be updated once https://github.com/vlang/v/issues/20000 is fixed, since otherwise it will be a lot of manual work or needs special purpose built tooling.

**EDIT**
Fixed by @StunxFS in <https://github.com/vlang/v/pull/20005>