### PR TITLE
ci: prepend `VJOBS=1` to flaky format tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,8 @@ jobs:
       - name: Test code formatting
         run: |
           cd sdl
-          v test-fmt
-          v fmt -verify .
+          VJOBS=1 v test-fmt
+          VJOBS=1 v fmt -verify .
 
       - name: Build sdl shared
         run: |


### PR DESCRIPTION
these tests often fail on the macOS runner, even though the files *are* formatted properly