### PR TITLE
examples: migrate to using `import sdl.callbacks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,31 @@ You can read more about this compatibility in regards to V in the
 ### Using SDL3 `SDL_App*` callbacks (and running *some* examples)
 
 To use SDL3's *main-loop control inversion* / callback setup via
-`SDL_MAIN_USE_CALLBACKS`. You will need to `@[export]` 4 specially named
-functions and compile the code with `-d sdl_callbacks`.
+`SDL_MAIN_USE_CALLBACKS`. You will need to `import sdl.callbacks`,
+then define:
+```v oksyntax
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_event(app_event)
+	callbacks.on_iterate(app_iterate)
+}
+```
 
-The examples in `examples/ports/*` all require the build flag
-`-d sdl_callbacks` to function as intended without a main function.
+Note that if the code for some of the callbacks is trivial, you do not have
+to register it, just skip the call to the corresponding `on_` function.
 
-The examples *outside* the `ports` folder can be run normally.
+The examples in `examples/ports/*` all function without a main
+function, using that scheme.
+
+The examples *outside* the `ports` folder, use the normal `fn main()
+{` mechanism, without having to register callbacks.
 
 Whether or not you want to use the "no main" approach for your own apps
 is up to you. V supports both ways for building SDL3 applications.
 
-Read more about the no main, callbacks and reasons in `examples/ports/README.md`(examples/ports/README.md).
+Read more about the no main, callbacks and reasons 
+in `examples/ports/README.md`(examples/ports/README.md).
 
 ### Notes on garbage collection and memory issues
 
@@ -161,7 +174,7 @@ Various examples of running some of the included examples.
 ```bash
 v run ~/.vmodules/sdl/examples/basic_window/
 v run ~/.vmodules/sdl/examples/versions/
-v -d sdl_callbacks run ~/.vmodules/sdl/examples/ports/template.v
+v run ~/.vmodules/sdl/examples/ports/template.v
 # See `examples/ports/README.md` for more info on `SDL_MAIN_USE_CALLBACKS`.
 ```
 
@@ -178,7 +191,7 @@ make install # should install to something like $HOME/.cache/emscripten/sysroot/
 ```bash
 export PKG_CONFIG_PATH_DEFAULTS=$HOME/.cache/emscripten/sysroot/lib/pkgconfig/
 mkdir /tmp/sdl_wasm
-v -os wasm32_emscripten -gc none -d sdl_callbacks -o /tmp/sdl_wasm/example.html ~/.vmodules/sdl/examples/ports/renderer/05-rectangles/
+v -os wasm32_emscripten -gc none -o /tmp/sdl_wasm/example.html ~/.vmodules/sdl/examples/ports/renderer/05-rectangles/
 emrun /tmp/sdl_wasm/example.html
 ```
 
@@ -191,5 +204,7 @@ for more information.
 Example of building an `.apk` for `arm64-v8a`:
 
 ```bash
-vab sdl --assets ~/.vmodules/sdl/examples/assets/ --flag "-d sdl_callbacks" --archs "arm64-v8a" ~/.vmodules/sdl/examples/ports/renderer/06-textures/
+vab sdl --assets ~/.vmodules/sdl/examples/assets/ \
+        --archs "arm64-v8a" \
+		~/.vmodules/sdl/examples/ports/renderer/06-textures/
 ```

--- a/audio.c.v
+++ b/audio.c.v
@@ -258,7 +258,7 @@ fn C.SDL_GetAudioDriver(index int) &char
 //
 // See also: get_num_audio_drivers (SDL_GetNumAudioDrivers)
 pub fn get_audio_driver(index int) &char {
-	return C.SDL_GetAudioDriver(index)
+	return &char(C.SDL_GetAudioDriver(index))
 }
 
 // C.SDL_GetCurrentAudioDriver [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetCurrentAudioDriver)
@@ -277,7 +277,7 @@ fn C.SDL_GetCurrentAudioDriver() &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_current_audio_driver() &char {
-	return C.SDL_GetCurrentAudioDriver()
+	return &char(C.SDL_GetCurrentAudioDriver())
 }
 
 // C.SDL_GetAudioPlaybackDevices [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetAudioPlaybackDevices)
@@ -360,7 +360,7 @@ fn C.SDL_GetAudioDeviceName(devid AudioDeviceID) &char
 // See also: get_audio_playback_devices (SDL_GetAudioPlaybackDevices)
 // See also: get_audio_recording_devices (SDL_GetAudioRecordingDevices)
 pub fn get_audio_device_name(devid AudioDeviceID) &char {
-	return C.SDL_GetAudioDeviceName(devid)
+	return &char(C.SDL_GetAudioDeviceName(devid))
 }
 
 // C.SDL_GetAudioDeviceFormat [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetAudioDeviceFormat)
@@ -766,7 +766,7 @@ fn C.SDL_BindAudioStreams(devid AudioDeviceID, const_streams &&C.SDL_AudioStream
 // See also: unbind_audio_stream (SDL_UnbindAudioStream)
 // See also: get_audio_stream_device (SDL_GetAudioStreamDevice)
 pub fn bind_audio_streams(devid AudioDeviceID, const_streams &&C.SDL_AudioStream, num_streams int) bool {
-	return C.SDL_BindAudioStreams(devid, const_streams, num_streams)
+	return C.SDL_BindAudioStreams(devid, voidptr(const_streams), num_streams)
 }
 
 // C.SDL_BindAudioStream [official documentation](https://wiki.libsdl.org/SDL3/SDL_BindAudioStream)
@@ -814,7 +814,7 @@ fn C.SDL_UnbindAudioStreams(const_streams &&C.SDL_AudioStream, num_streams int)
 //
 // See also: bind_audio_streams (SDL_BindAudioStreams)
 pub fn unbind_audio_streams(const_streams &&C.SDL_AudioStream, num_streams int) {
-	C.SDL_UnbindAudioStreams(const_streams, num_streams)
+	C.SDL_UnbindAudioStreams(voidptr(const_streams), num_streams)
 }
 
 // C.SDL_UnbindAudioStream [official documentation](https://wiki.libsdl.org/SDL3/SDL_UnbindAudioStream)
@@ -2082,7 +2082,7 @@ fn C.SDL_GetAudioFormatName(format AudioFormat) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_audio_format_name(format AudioFormat) &char {
-	return C.SDL_GetAudioFormatName(format)
+	return &char(C.SDL_GetAudioFormatName(format))
 }
 
 // C.SDL_GetSilenceValueForFormat [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetSilenceValueForFormat)

--- a/c/sdl.c.v
+++ b/c/sdl.c.v
@@ -31,8 +31,8 @@ $if x64 {
 
 // NOTE::
 // See the files:
-// ./implement_d_sdl_callbacks.c.v
-// ./implement_notd_sdl_callbacks.c.v
-// ./sdl_main_use_callbacks_shim.h
-// ./../examples/ports/README.md
+// ../examples/ports/README.md
+// ./sdl_main_use_callbacks_preinclude.h
+// ./sdl_main_use_callbacks_include.h
+// ./sdl_main_use_callbacks_postinclude.h
 // ... for V's support of SDL3's *main-loop control inversion*.

--- a/c/sdl_main_use_callbacks_include.h
+++ b/c/sdl_main_use_callbacks_include.h
@@ -1,0 +1,24 @@
+#include <SDL3/SDL_main.h>
+
+// See also `sdl_main_use_callbacks_preinclude.h`.
+// See also `sdl_main_use_callbacks_postinclude.h`.
+//
+// These are the default functions, that will be called, when the app does not define any override.
+// They do nothing, they just simplify the logic in the actual SDL handlers.
+// See also `sdl_main_use_callbacks_shim.h`
+SDL_AppResult nop_sdl_app_init(void    **appstate, int argc, char *argv[]) { return SDL_APP_CONTINUE; }
+void          nop_sdl_app_quit(void     *appstate, SDL_AppResult result)   {};
+SDL_AppResult nop_sdl_app_event(void    *appstate, SDL_Event *event)       {
+   	if(event->type == SDL_EVENT_QUIT) {
+		return SDL_APP_SUCCESS; // end the program, reporting success to the OS.
+	}
+	return SDL_APP_CONTINUE;
+}
+SDL_AppResult nop_sdl_app_iterate(void  *appstate)                         { return SDL_APP_CONTINUE; }
+
+// These callbacks should be changed, when the app wants to override something:
+SDL_AppResult (*g_sdl_app_init)(void   **appstate, int argc, char *argv[]) = nop_sdl_app_init;
+void          (*g_sdl_app_quit)(void    *appstate, SDL_AppResult result)   = nop_sdl_app_quit;
+SDL_AppResult (*g_sdl_app_event)(void   *appstate, SDL_Event *event)       = nop_sdl_app_event;
+SDL_AppResult (*g_sdl_app_iterate)(void *appstate)                         = nop_sdl_app_iterate;
+

--- a/c/sdl_main_use_callbacks_postinclude.h
+++ b/c/sdl_main_use_callbacks_postinclude.h
@@ -1,0 +1,31 @@
+// See also `sdl_main_use_callbacks_preinclude.h`.
+// See also `sdl_main_use_callbacks_include.h`.
+// 
+// This is a C shim to make it possible to use SDL3's implementation
+// of the main-loop control inversion that more and more
+// platforms promote and use (callbacks for program init,loop,event/block,quit).
+// NOTE: Read more about the setup and reasons for this in `examples/ports/README.md`.
+		   
+SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[]) {
+	g_main_argc = argc;
+	g_main_argv = argv;
+	# if defined(_VGCBOEHM)
+		GC_set_pages_executable(0);
+		GC_INIT();
+	#endif
+	_vinit(argc, argv);
+	return g_sdl_app_init(appstate, argc, argv);
+}
+
+void SDL_AppQuit(void *appstate, SDL_AppResult result) {
+	g_sdl_app_quit(appstate, result);
+	_vcleanup();
+}
+
+SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event) {
+	return g_sdl_app_event(appstate, event);
+}
+
+SDL_AppResult SDL_AppIterate(void *appstate) {  
+	return g_sdl_app_iterate(appstate);
+}

--- a/c/sdl_main_use_callbacks_preinclude.h
+++ b/c/sdl_main_use_callbacks_preinclude.h
@@ -1,0 +1,7 @@
+// See also `sdl_main_use_callbacks_include.h`.
+// See also `sdl_main_use_callbacks_postinclude.h`.
+#define SDL_MAIN_USE_CALLBACKS
+
+#ifdef _WIN32
+#define UNICODE 1 // Fix: fatal error C1017: invalid integer constant expression
+#endif

--- a/c/sdl_main_use_callbacks_shim.h
+++ b/c/sdl_main_use_callbacks_shim.h
@@ -1,3 +1,7 @@
+/*** this file is not used anymore; it is here just for backwards compatibility ***/
+/*** TODO: change this pragma from message to a `#pragma GCC error` ***/
+#pragma message "Using sdl_main_use_callbacks_shim.h is not needed anymore; use `import sdl.callbacks` instead"
+
 #if defined(SDL_MAIN_USE_CALLBACKS)
 
 // This is a C shim to make it possible to use SDL3's implementation

--- a/callbacks/on.v
+++ b/callbacks/on.v
@@ -1,0 +1,31 @@
+module callbacks
+
+import sdl
+
+#preinclude  "@VMODROOT/c/sdl_main_use_callbacks_preinclude.h"
+#postinclude "@VMODROOT/c/sdl_main_use_callbacks_postinclude.h"
+#include     "@VMODROOT/c/sdl_main_use_callbacks_include.h"
+
+pub fn on_init(f sdl.AppInitFunc) {
+	unsafe {
+		*&sdl.AppInitFunc(&C.g_sdl_app_init) = voidptr(f)
+	}
+}
+
+pub fn on_quit(f sdl.AppQuitFunc) {
+	unsafe {
+		*&sdl.AppQuitFunc(&C.g_sdl_app_quit) = voidptr(f)
+	}
+}
+
+pub fn on_event(f sdl.AppEventFunc) {
+	unsafe {
+		*&sdl.AppEventFunc(&C.g_sdl_app_event) = voidptr(f)
+	}
+}
+
+pub fn on_iterate(f sdl.AppIterateFunc) {
+	unsafe {
+		*&sdl.AppIterateFunc(&C.g_sdl_app_iterate) = voidptr(f)
+	}
+}

--- a/callbacks/on.v
+++ b/callbacks/on.v
@@ -6,24 +6,32 @@ import sdl
 #postinclude "@VMODROOT/c/sdl_main_use_callbacks_postinclude.h"
 #include     "@VMODROOT/c/sdl_main_use_callbacks_include.h"
 
+// on_init will make SDL3 call the passed function callback `f`,
+// when it will call https://wiki.libsdl.org/SDL3/SDL_AppInit .
 pub fn on_init(f sdl.AppInitFunc) {
 	unsafe {
 		*&sdl.AppInitFunc(&C.g_sdl_app_init) = voidptr(f)
 	}
 }
 
+// on_quit will make SDL3 call the passed function callback `f`,
+// when it will call https://wiki.libsdl.org/SDL3/SDL_AppQuit .
 pub fn on_quit(f sdl.AppQuitFunc) {
 	unsafe {
 		*&sdl.AppQuitFunc(&C.g_sdl_app_quit) = voidptr(f)
 	}
 }
 
+// on_event will make SDL3 call the passed function callback `f`,
+// when it will call https://wiki.libsdl.org/SDL3/SDL_AppEvent .
 pub fn on_event(f sdl.AppEventFunc) {
 	unsafe {
 		*&sdl.AppEventFunc(&C.g_sdl_app_event) = voidptr(f)
 	}
 }
 
+// on_iterate will make SDL3 call the passed function callback `f`,
+// when it will call https://wiki.libsdl.org/SDL3/SDL_AppIterate .
 pub fn on_iterate(f sdl.AppIterateFunc) {
 	unsafe {
 		*&sdl.AppIterateFunc(&C.g_sdl_app_iterate) = voidptr(f)

--- a/camera.c.v
+++ b/camera.c.v
@@ -138,7 +138,7 @@ fn C.SDL_GetCameraDriver(index int) &char
 //
 // See also: get_num_camera_drivers (SDL_GetNumCameraDrivers)
 pub fn get_camera_driver(index int) &char {
-	return C.SDL_GetCameraDriver(index)
+	return &char(C.SDL_GetCameraDriver(index))
 }
 
 // C.SDL_GetCurrentCameraDriver [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetCurrentCameraDriver)
@@ -157,7 +157,7 @@ fn C.SDL_GetCurrentCameraDriver() &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_current_camera_driver() &char {
-	return C.SDL_GetCurrentCameraDriver()
+	return &char(C.SDL_GetCurrentCameraDriver())
 }
 
 // C.SDL_GetCameras [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetCameras)
@@ -237,7 +237,7 @@ fn C.SDL_GetCameraName(instance_id CameraID) &char
 //
 // See also: get_cameras (SDL_GetCameras)
 pub fn get_camera_name(instance_id CameraID) &char {
-	return C.SDL_GetCameraName(instance_id)
+	return &char(C.SDL_GetCameraName(instance_id))
 }
 
 // C.SDL_GetCameraPosition [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetCameraPosition)

--- a/examples/ports/README.md
+++ b/examples/ports/README.md
@@ -1,61 +1,66 @@
 # README
 
-The examples in this directory are the [official SDL3 examples](https://examples.libsdl.org/SDL3/)
-ported from C source code to V source code.
+The examples in this directory are the 
+[official SDL3 examples](https://examples.libsdl.org/SDL3/) ported from C
+source code to V source code.
 
-To compile and run the examples you need to pass `-d sdl_callbacks` to
-the V compiler when building. Not doing so can end up with a build output similar to the
-following:
-```
-error: function `main` must be declared in the main module
-```
-The first renderer example (`renderer/01-clear`) has comments containing the original ported C source lines
-above the corresponding V code to help clarify how the C source is ported.
-Other examples may only have the original C source *comments*.
+The first renderer example (`renderer/01-clear`) has comments containing the
+original ported C source lines above the corresponding V code to help clarify
+how the C source is ported. Other examples may only have the original C
+source *comments*.
 
 Comments are preserved for educational purposes and to aid port navigation.
 
 ## Why/how the examples/ports work without a `fn main() {}` in V
 
 The examples in this directory (and likely more SDL3 based V apps)
-has `module no_main` and no `fn main() {}` definition, but can still compile and run.
+has `module no_main` and no `fn main() {}` definition, but can still compile
+and run.
 
-This is only possible if the program is built using the flag `-d sdl_callbacks`.
-For SDL3's setup specifically, the programmer also need to implement 4 special
-functions and `@[export]` them with special names:
+This is only possible, if the program imports `sdl.callbacks`, which does the
+necessary callback setup for SDL3 specifically.
 
-```v
-// Omitted fn main() {}, instead:
-
+```v oksyntax
+// Note, there is no `fn main() {}`, here, but instead:
 module no_main
 
-@[export: 'v_sdl_app_init'] // Exported name(s) have significant importance
-pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {}
+import sdl
+import sdl.callbacks
 
-@[export: 'v_sdl_app_event'] // Exported name(s) have significant importance
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {}
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_event(app_event)
+	callbacks.on_iterate(app_iterate)
+}
 
-@[export: 'v_sdl_app_iterate'] // Exported name(s) have significant importance
-pub fn app_iterate(appstate voidptr) sdl.AppResult {}
+fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {}
 
-@[export: 'v_sdl_app_quit'] // Exported name(s) have significant importance
-pub fn app_quit(appstate voidptr, result sdl.AppResult) {}
+fn app_quit(appstate voidptr, result sdl.AppResult) {}
+
+fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {}
+
+fn app_iterate(appstate voidptr) sdl.AppResult {}
 ```
 
-The reason this magic works is because of `module no_main` in combination with [a C shim](https://github.com/vlang/sdl/blob/3.2.0/c/sdl_main_use_callbacks_shim.h)
-that makes it possible to use SDL3's implementation of the *main-loop control inversion* scheme
-(aka. callbacks for program initialization, main loop, events (blocking code) and quit/cleanup).
-More and more platforms promote and make use of this scheme, whether people like it or not.
+The reason this magic works is because of `module no_main` in
+combination with [a C shim](https://github.com/vlang/sdl/blob/3.2.0/c/sdl_main_use_callbacks_postinclude.h)
+that makes it possible to use SDL3's implementation of the 
+*main-loop control inversion* scheme (aka. callbacks for program 
+initialization, main loop, events (blocking code) and quit/cleanup).
+More and more platforms promote and make use of this scheme, whether
+people like it or not.
 
-The example `examples/ports/template..` is a commented example that illustrate how the code
-needs to be written for `SDL_MAIN_USE_CALLBACKS` to work in V.
+The example `examples/ports/template..` is a commented example that
+illustrate how the code needs to be written for `SDL_MAIN_USE_CALLBACKS`
+to work in V.
 
-SDL3 has chosen to support the *main-loop control inversion* and make it
-a first-class citizen in SDL3. The official SDL3 examples, written in C,
-use the mentioned callback scheme, so to help ease and understand better the
-V equivalents in `examples/ports`, `vlang/sdl` show how it is possible
-to use this more magic, implicit and somewhat awkward code setup to build
-and run SDL3 applications coded using the scheme.
+SDL3 has chosen to support the *main-loop control inversion* and make it a
+first-class citizen in SDL3. The official SDL3 examples, written in C, use
+the mentioned callback scheme, so to help ease and understand better the V
+equivalents in `examples/ports`, `vlang/sdl` show how it is possible to use
+this more magic, implicit and somewhat awkward code setup to build and run
+SDL3 applications coded using the scheme.
 
 Read more about SDL3's handling of the `main` function here:
 [https://wiki.libsdl.org/SDL3/README/main-functions](https://wiki.libsdl.org/SDL3/README/main-functions)
@@ -63,6 +68,6 @@ Read more about SDL3's handling of the `main` function here:
 ... and more about the initial reasoning here:
 [https://github.com/libsdl-org/SDL/issues/6785](https://github.com/libsdl-org/SDL/issues/6785)
 
-It is utilized in these V ports to ease the porting of SDL3 examples
-and apps to V, since this is what SDL3 promote as their
-recommended way of doing SDL3 applications.
+It is utilized in these V ports to ease the porting of SDL3 examples and apps
+to V, since this is what SDL3 promote as their recommended way of doing SDL3
+applications.

--- a/examples/ports/renderer/01-clear/clear.v
+++ b/examples/ports/renderer/01-clear/clear.v
@@ -3,7 +3,6 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.

--- a/examples/ports/renderer/01-clear/clear.v
+++ b/examples/ports/renderer/01-clear/clear.v
@@ -8,8 +8,14 @@ module no_main
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
 import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_event(app_event)
+	callbacks.on_iterate(app_iterate)
+}
 
 // Ported from clear.c https://examples.libsdl.org/SDL3/renderer/01-clear/
 //
@@ -30,7 +36,6 @@ struct SDLApp {
 
 // This function runs once at startup.
 // SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	// Allocate / instantiate the state struct on the heap
 	mut app := &SDLApp{}
@@ -63,9 +68,14 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue
 }
 
+// This function runs once at shutdown.
+// void SDL_AppQuit(void *appstate, SDL_AppResult result)
+pub fn app_quit(appstate voidptr, result sdl.AppResult) {
+	//     /* SDL will clean up the window/renderer for us. */
+}
+
 // This function runs when a new event (mouse input, keypresses, etc) occurs.
 // SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
-@[export: 'v_sdl_app_event']
 pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
 	//     if (event->type == SDL_EVENT_QUIT) {
 	//         return SDL_APP_SUCCESS;  /* end the program, reporting success to the OS. */
@@ -82,7 +92,6 @@ pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
 
 // This function runs once per frame, and is the heart of the program.
 // SDL_AppResult SDL_AppIterate(void *appstate)
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) } // Retreive the state struct we initialized in `app_init`.
 
@@ -106,11 +115,4 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	//
 	//     return SDL_APP_CONTINUE;  /* carry on with the program! */
 	return .continue
-}
-
-// This function runs once at shutdown.
-// void SDL_AppQuit(void *appstate, SDL_AppResult result)
-@[export: 'v_sdl_app_quit']
-pub fn app_quit(appstate voidptr, result sdl.AppResult) {
-	//     /* SDL will clean up the window/renderer for us. */
 }

--- a/examples/ports/renderer/02-primitives/primitives.v
+++ b/examples/ports/renderer/02-primitives/primitives.v
@@ -3,7 +3,6 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.

--- a/examples/ports/renderer/02-primitives/primitives.v
+++ b/examples/ports/renderer/02-primitives/primitives.v
@@ -8,8 +8,12 @@ module no_main
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
 import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_iterate(app_iterate)
+}
 
 // Ported from primitives.c https://examples.libsdl.org/SDL3/renderer/02-primitives/
 
@@ -27,7 +31,6 @@ mut:
 }
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -57,20 +60,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -105,10 +95,4 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	sdl.render_line(app.renderer, 0, 480, 640, 0)
 	sdl.render_present(app.renderer) // put it all on the screen!
 	return .continue
-}
-
-// This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
-pub fn app_quit(appstate voidptr, result sdl.AppResult) {
-	// SDL will clean up the window/renderer for us.
 }

--- a/examples/ports/renderer/03-lines/lines.v
+++ b/examples/ports/renderer/03-lines/lines.v
@@ -3,13 +3,16 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
 import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_iterate(app_iterate)
+}
 
 // Ported from lines.c https://examples.libsdl.org/SDL3/renderer/03-lines/
 
@@ -26,7 +29,6 @@ mut:
 }
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -50,20 +52,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -113,10 +102,4 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	sdl.render_present(app.renderer) // put it all on the screen!
 
 	return .continue
-}
-
-// This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
-pub fn app_quit(appstate voidptr, result sdl.AppResult) {
-	// SDL will clean up the window/renderer for us.
 }

--- a/examples/ports/renderer/04-points/points.v
+++ b/examples/ports/renderer/04-points/points.v
@@ -3,13 +3,16 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
 import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_iterate(app_iterate)
+}
 
 // Ported from points.c https://examples.libsdl.org/SDL3/renderer/04-points/
 
@@ -44,7 +47,6 @@ const min_pixels_per_second = 30 // move at least this many pixels per second.
 const max_pixels_per_second = 60 // move this many pixels per second at most.
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -78,20 +80,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -132,10 +121,4 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	sdl.render_present(app.renderer) // put it all on the screen!
 
 	return .continue // carry on with the program!
-}
-
-// This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
-pub fn app_quit(appstate voidptr, result sdl.AppResult) {
-	// SDL will clean up the window/renderer for us.
 }

--- a/examples/ports/renderer/05-rectangles/rectangles.v
+++ b/examples/ports/renderer/05-rectangles/rectangles.v
@@ -3,13 +3,16 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
 import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_iterate(app_iterate)
+}
 
 // Ported from rectangles.c https://examples.libsdl.org/SDL3/renderer/05-rectangles/
 
@@ -29,7 +32,6 @@ const window_width = 640
 const window_height = 480
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -53,20 +55,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -128,10 +117,4 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	sdl.render_present(app.renderer) // put it all on the screen!
 
 	return .continue // carry on with the program!
-}
-
-// This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
-pub fn app_quit(appstate voidptr, result sdl.AppResult) {
-	// SDL will clean up the window/renderer for us.
 }

--- a/examples/ports/renderer/06-textures/textures.v
+++ b/examples/ports/renderer/06-textures/textures.v
@@ -3,7 +3,6 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.

--- a/examples/ports/renderer/06-textures/textures.v
+++ b/examples/ports/renderer/06-textures/textures.v
@@ -7,10 +7,15 @@ module no_main
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
-import sdl
 import os
+import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_iterate(app_iterate)
+}
 
 #flag wasm32_emscripten --embed-file "@VMODROOT/examples/assets/images/sample.bmp@images/sample.bmp"
 
@@ -47,7 +52,6 @@ fn get_asset_path(path string) string {
 }
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -97,20 +101,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -158,7 +149,6 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 }
 
 // This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
 pub fn app_quit(appstate voidptr, result sdl.AppResult) {
 	mut app := unsafe { &SDLApp(appstate) }
 	sdl.destroy_texture(app.texture)

--- a/examples/ports/renderer/07-streaming-textures/streaming-textures.v
+++ b/examples/ports/renderer/07-streaming-textures/streaming-textures.v
@@ -3,13 +3,17 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
 import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_iterate(app_iterate)
+}
 
 // Ported from streaming-textures.c https://examples.libsdl.org/SDL3/renderer/07-streaming-textures/
 
@@ -32,7 +36,6 @@ const window_width = 640
 const window_height = 480
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -64,20 +67,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -137,7 +127,6 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 }
 
 // This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
 pub fn app_quit(appstate voidptr, result sdl.AppResult) {
 	mut app := unsafe { &SDLApp(appstate) }
 	sdl.destroy_texture(app.texture)

--- a/examples/ports/renderer/08-rotating-textures/rotating-textures.v
+++ b/examples/ports/renderer/08-rotating-textures/rotating-textures.v
@@ -3,14 +3,18 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
-import sdl
 import os
+import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_iterate(app_iterate)
+}
 
 #flag wasm32_emscripten --embed-file "@VMODROOT/examples/assets/images/sample.bmp@images/sample.bmp"
 
@@ -47,7 +51,6 @@ fn get_asset_path(path string) string {
 }
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -97,20 +100,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -143,7 +133,6 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 }
 
 // This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
 pub fn app_quit(appstate voidptr, result sdl.AppResult) {
 	mut app := unsafe { &SDLApp(appstate) }
 	sdl.destroy_texture(app.texture)

--- a/examples/ports/renderer/09-scaling-textures/scaling-textures.v
+++ b/examples/ports/renderer/09-scaling-textures/scaling-textures.v
@@ -3,14 +3,18 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
-import sdl
 import os
+import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_iterate(app_iterate)
+}
 
 #flag wasm32_emscripten --embed-file "@VMODROOT/examples/assets/images/sample.bmp@images/sample.bmp"
 
@@ -47,7 +51,6 @@ fn get_asset_path(path string) string {
 }
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -97,20 +100,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -140,7 +130,6 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 }
 
 // This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
 pub fn app_quit(appstate voidptr, result sdl.AppResult) {
 	mut app := unsafe { &SDLApp(appstate) }
 	sdl.destroy_texture(app.texture)

--- a/examples/ports/renderer/10-geometry/geometry.v
+++ b/examples/ports/renderer/10-geometry/geometry.v
@@ -3,14 +3,18 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
 // See also: `examples/ports/template.v` for a simple commented example demonstrating how
 // to run via callbacks instead of a `fn main() {}`.
 // See also: `examples/ports/README.md` for more information.
-import sdl
 import os
+import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_iterate(app_iterate)
+}
 
 #flag wasm32_emscripten --embed-file "@VMODROOT/examples/assets/images/sample.bmp@images/sample.bmp"
 
@@ -47,7 +51,6 @@ fn get_asset_path(path string) string {
 }
 
 // This function runs once at startup.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	mut app := &SDLApp{}
 	unsafe {
@@ -97,20 +100,7 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	return .continue // carry on with the program!
 }
 
-// This function runs when a new event (mouse input, keypresses, etc) occurs.
-@[export: 'v_sdl_app_event']
-pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
-	match event.type {
-		.quit {
-			return .success // end the program, reporting success to the OS.
-		}
-		else {}
-	}
-	return .continue // carry on with the program!
-}
-
 // This function runs once per frame, and is the heart of the program.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) }
 
@@ -191,7 +181,6 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 }
 
 // This function runs once at shutdown.
-@[export: 'v_sdl_app_quit']
 pub fn app_quit(appstate voidptr, result sdl.AppResult) {
 	mut app := unsafe { &SDLApp(appstate) }
 	sdl.destroy_texture(app.texture)

--- a/examples/ports/template.v
+++ b/examples/ports/template.v
@@ -3,13 +3,19 @@
 // that can be found in the LICENSE file.
 module no_main
 
-// NOTE: compile this example with `-d sdl_callbacks`.
-// We use `module no_main` and do not define `fn main() {}` in any of the ported
-// examples since they use the SDL3 `SDL_App*` callback scheme implemented as a shim in C.
+// We use `module no_main` and do not define `fn main() {}` in any of the ported examples.
+// Instead, we do register our callback functions in the module's init function.
+// The sdl.callbacks module, uses the SDL3 `SDL_App*` callback scheme.
 // Read more about the setup and reasons for this in `examples/ports/README.md`.
 import sdl
+import sdl.callbacks
 
-#postinclude "@VMODROOT/c/sdl_main_use_callbacks_shim.h"
+fn init() {
+	callbacks.on_init(app_init)
+	callbacks.on_quit(app_quit)
+	callbacks.on_event(app_event)
+	callbacks.on_iterate(app_iterate)
+}
 
 // SDLApp is dedicated to hold the complete state of the application.
 struct SDLApp {
@@ -18,8 +24,6 @@ struct SDLApp {
 }
 
 // app_init runs once at startup.
-// NOTE: the exported name has significance since it is called from C so it should not be changed.
-@[export: 'v_sdl_app_init']
 pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 	// Allocate / instantiate the state struct on the heap
 	mut app := &SDLApp{}
@@ -43,8 +47,6 @@ pub fn app_init(appstate &voidptr, argc int, argv &&char) sdl.AppResult {
 }
 
 // app_event runs when a new event (mouse input, keypresses, etc) occurs.
-// NOTE: the exported name has significance since it is called from C so it should not be changed.
-@[export: 'v_sdl_app_event']
 pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
 	match event.type {
 		.quit {
@@ -56,8 +58,6 @@ pub fn app_event(appstate voidptr, event &sdl.Event) sdl.AppResult {
 }
 
 // app_iterate runs once per frame, and is the heart of the program.
-// NOTE: the exported name has significance since it is called from C so it should not be changed.
-@[export: 'v_sdl_app_iterate']
 pub fn app_iterate(appstate voidptr) sdl.AppResult {
 	mut app := unsafe { &SDLApp(appstate) } // Retreive the state struct we initialized in `app_init`.
 	sdl.set_render_draw_color_float(app.renderer, 0.5, 0.5, 1.0, sdl.alpha_opaque)
@@ -67,8 +67,6 @@ pub fn app_iterate(appstate voidptr) sdl.AppResult {
 }
 
 // app_quit runs once at shutdown.
-// NOTE: the exported name has significance since it is called from C so it should not be changed.
-@[export: 'v_sdl_app_quit']
 pub fn app_quit(appstate voidptr, result sdl.AppResult) {
 	// SDL will clean up the window/renderer for us.
 }

--- a/filesystem.c.v
+++ b/filesystem.c.v
@@ -74,7 +74,7 @@ fn C.SDL_GetBasePath() &char
 //
 // See also: get_pref_path (SDL_GetPrefPath)
 pub fn get_base_path() &char {
-	return C.SDL_GetBasePath()
+	return &char(C.SDL_GetBasePath())
 }
 
 // C.SDL_GetPrefPath [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetPrefPath)
@@ -132,7 +132,7 @@ fn C.SDL_GetPrefPath(const_org &char, const_app &char) &char
 //
 // See also: get_base_path (SDL_GetBasePath)
 pub fn get_pref_path(const_org &char, const_app &char) &char {
-	return C.SDL_GetPrefPath(const_org, const_app)
+	return &char(C.SDL_GetPrefPath(const_org, const_app))
 }
 
 // Folder is C.SDL_Folder
@@ -176,7 +176,7 @@ fn C.SDL_GetUserFolder(folder Folder) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_user_folder(folder Folder) &char {
-	return C.SDL_GetUserFolder(folder)
+	return &char(C.SDL_GetUserFolder(folder))
 }
 
 // PathType is C.SDL_PathType
@@ -438,5 +438,5 @@ fn C.SDL_GetCurrentDirectory() &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_current_directory() &char {
-	return C.SDL_GetCurrentDirectory()
+	return &char(C.SDL_GetCurrentDirectory())
 }

--- a/gamepad.c.v
+++ b/gamepad.c.v
@@ -457,7 +457,7 @@ fn C.SDL_GetGamepadNameForID(instance_id JoystickID) &char
 // See also: get_gamepad_name (SDL_GetGamepadName)
 // See also: get_gamepads (SDL_GetGamepads)
 pub fn get_gamepad_name_for_id(instance_id JoystickID) &char {
-	return C.SDL_GetGamepadNameForID(instance_id)
+	return &char(C.SDL_GetGamepadNameForID(instance_id))
 }
 
 // C.SDL_GetGamepadPathForID [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGamepadPathForID)
@@ -476,7 +476,7 @@ fn C.SDL_GetGamepadPathForID(instance_id JoystickID) &char
 // See also: get_gamepad_path (SDL_GetGamepadPath)
 // See also: get_gamepads (SDL_GetGamepads)
 pub fn get_gamepad_path_for_id(instance_id JoystickID) &char {
-	return C.SDL_GetGamepadPathForID(instance_id)
+	return &char(C.SDL_GetGamepadPathForID(instance_id))
 }
 
 // C.SDL_GetGamepadPlayerIndexForID [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGamepadPlayerIndexForID)
@@ -630,7 +630,7 @@ fn C.SDL_GetGamepadMappingForID(instance_id JoystickID) &char
 // See also: get_gamepads (SDL_GetGamepads)
 // See also: get_gamepad_mapping (SDL_GetGamepadMapping)
 pub fn get_gamepad_mapping_for_id(instance_id JoystickID) &char {
-	return C.SDL_GetGamepadMappingForID(instance_id)
+	return &char(C.SDL_GetGamepadMappingForID(instance_id))
 }
 
 // C.SDL_OpenGamepad [official documentation](https://wiki.libsdl.org/SDL3/SDL_OpenGamepad)
@@ -750,7 +750,7 @@ fn C.SDL_GetGamepadName(gamepad &Gamepad) &char
 //
 // See also: get_gamepad_name_for_id (SDL_GetGamepadNameForID)
 pub fn get_gamepad_name(gamepad &Gamepad) &char {
-	return C.SDL_GetGamepadName(gamepad)
+	return &char(C.SDL_GetGamepadName(gamepad))
 }
 
 // C.SDL_GetGamepadPath [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGamepadPath)
@@ -767,7 +767,7 @@ fn C.SDL_GetGamepadPath(gamepad &Gamepad) &char
 //
 // See also: get_gamepad_path_for_id (SDL_GetGamepadPathForID)
 pub fn get_gamepad_path(gamepad &Gamepad) &char {
-	return C.SDL_GetGamepadPath(gamepad)
+	return &char(C.SDL_GetGamepadPath(gamepad))
 }
 
 // C.SDL_GetGamepadType [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGamepadType)
@@ -915,7 +915,7 @@ fn C.SDL_GetGamepadSerial(gamepad &Gamepad) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_gamepad_serial(gamepad &Gamepad) &char {
-	return C.SDL_GetGamepadSerial(gamepad)
+	return &char(C.SDL_GetGamepadSerial(gamepad))
 }
 
 // C.SDL_GetGamepadSteamHandle [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGamepadSteamHandle)
@@ -1111,7 +1111,7 @@ fn C.SDL_GetGamepadStringForType(typ GamepadType) &char
 //
 // See also: get_gamepad_type_from_string (SDL_GetGamepadTypeFromString)
 pub fn get_gamepad_string_for_type(typ GamepadType) &char {
-	return C.SDL_GetGamepadStringForType(typ)
+	return &char(C.SDL_GetGamepadStringForType(typ))
 }
 
 // C.SDL_GetGamepadAxisFromString [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGamepadAxisFromString)
@@ -1153,7 +1153,7 @@ fn C.SDL_GetGamepadStringForAxis(axis GamepadAxis) &char
 //
 // See also: get_gamepad_axis_from_string (SDL_GetGamepadAxisFromString)
 pub fn get_gamepad_string_for_axis(axis GamepadAxis) &char {
-	return C.SDL_GetGamepadStringForAxis(axis)
+	return &char(C.SDL_GetGamepadStringForAxis(axis))
 }
 
 // C.SDL_GamepadHasAxis [official documentation](https://wiki.libsdl.org/SDL3/SDL_GamepadHasAxis)
@@ -1238,7 +1238,7 @@ fn C.SDL_GetGamepadStringForButton(button GamepadButton) &char
 //
 // See also: get_gamepad_button_from_string (SDL_GetGamepadButtonFromString)
 pub fn get_gamepad_string_for_button(button GamepadButton) &char {
-	return C.SDL_GetGamepadStringForButton(button)
+	return &char(C.SDL_GetGamepadStringForButton(button))
 }
 
 // C.SDL_GamepadHasButton [official documentation](https://wiki.libsdl.org/SDL3/SDL_GamepadHasButton)
@@ -1578,7 +1578,7 @@ fn C.SDL_GetGamepadAppleSFSymbolsNameForButton(gamepad &Gamepad, button GamepadB
 //
 // See also: get_gamepad_apple_sf_symbols_name_for_axis (SDL_GetGamepadAppleSFSymbolsNameForAxis)
 pub fn get_gamepad_apple_sf_symbols_name_for_button(gamepad &Gamepad, button GamepadButton) &char {
-	return C.SDL_GetGamepadAppleSFSymbolsNameForButton(gamepad, button)
+	return &char(C.SDL_GetGamepadAppleSFSymbolsNameForButton(gamepad, button))
 }
 
 // C.SDL_GetGamepadAppleSFSymbolsNameForAxis [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGamepadAppleSFSymbolsNameForAxis)
@@ -1594,5 +1594,5 @@ fn C.SDL_GetGamepadAppleSFSymbolsNameForAxis(gamepad &Gamepad, axis GamepadAxis)
 //
 // See also: get_gamepad_apple_sf_symbols_name_for_button (SDL_GetGamepadAppleSFSymbolsNameForButton)
 pub fn get_gamepad_apple_sf_symbols_name_for_axis(gamepad &Gamepad, axis GamepadAxis) &char {
-	return C.SDL_GetGamepadAppleSFSymbolsNameForAxis(gamepad, axis)
+	return &char(C.SDL_GetGamepadAppleSFSymbolsNameForAxis(gamepad, axis))
 }

--- a/gpu.c.v
+++ b/gpu.c.v
@@ -1468,7 +1468,7 @@ fn C.SDL_GetGPUDriver(index int) &char
 //
 // See also: get_num_gpu_drivers (SDL_GetNumGPUDrivers)
 pub fn get_gpu_driver(index int) &char {
-	return C.SDL_GetGPUDriver(index)
+	return &char(C.SDL_GetGPUDriver(index))
 }
 
 // C.SDL_GetGPUDeviceDriver [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGPUDeviceDriver)
@@ -1481,7 +1481,7 @@ fn C.SDL_GetGPUDeviceDriver(device &GPUDevice) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_gpu_device_driver(device &GPUDevice) &char {
-	return C.SDL_GetGPUDeviceDriver(device)
+	return &char(C.SDL_GetGPUDeviceDriver(device))
 }
 
 // C.SDL_GetGPUShaderFormats [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetGPUShaderFormats)

--- a/haptic.c.v
+++ b/haptic.c.v
@@ -490,7 +490,7 @@ fn C.SDL_GetHapticNameForID(instance_id HapticID) &char
 // See also: get_haptic_name (SDL_GetHapticName)
 // See also: open_haptic (SDL_OpenHaptic)
 pub fn get_haptic_name_for_id(instance_id HapticID) &char {
-	return C.SDL_GetHapticNameForID(instance_id)
+	return &char(C.SDL_GetHapticNameForID(instance_id))
 }
 
 // C.SDL_OpenHaptic [official documentation](https://wiki.libsdl.org/SDL3/SDL_OpenHaptic)
@@ -563,7 +563,7 @@ fn C.SDL_GetHapticName(haptic &Haptic) &char
 //
 // See also: get_haptic_name_for_id (SDL_GetHapticNameForID)
 pub fn get_haptic_name(haptic &Haptic) &char {
-	return C.SDL_GetHapticName(haptic)
+	return &char(C.SDL_GetHapticName(haptic))
 }
 
 // C.SDL_IsMouseHaptic [official documentation](https://wiki.libsdl.org/SDL3/SDL_IsMouseHaptic)

--- a/hints.c.v
+++ b/hints.c.v
@@ -3868,7 +3868,7 @@ fn C.SDL_GetHint(const_name &char) &char
 // See also: set_hint (SDL_SetHint)
 // See also: set_hint_with_priority (SDL_SetHintWithPriority)
 pub fn get_hint(const_name &char) &char {
-	return C.SDL_GetHint(const_name)
+	return &char(C.SDL_GetHint(const_name))
 }
 
 // C.SDL_GetHintBoolean [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetHintBoolean)

--- a/init.c.v
+++ b/init.c.v
@@ -474,5 +474,5 @@ fn C.SDL_GetAppMetadataProperty(const_name &char) &char
 // See also: set_app_metadata (SDL_SetAppMetadata)
 // See also: set_app_metadata_property (SDL_SetAppMetadataProperty)
 pub fn get_app_metadata_property(const_name &char) &char {
-	return C.SDL_GetAppMetadataProperty(const_name)
+	return &char(C.SDL_GetAppMetadataProperty(const_name))
 }

--- a/joystick.c.v
+++ b/joystick.c.v
@@ -163,7 +163,7 @@ fn C.SDL_GetJoystickNameForID(instance_id JoystickID) &char
 // See also: get_joystick_name (SDL_GetJoystickName)
 // See also: get_joysticks (SDL_GetJoysticks)
 pub fn get_joystick_name_for_id(instance_id JoystickID) &char {
-	return C.SDL_GetJoystickNameForID(instance_id)
+	return &char(C.SDL_GetJoystickNameForID(instance_id))
 }
 
 // C.SDL_GetJoystickPathForID [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetJoystickPathForID)
@@ -182,7 +182,7 @@ fn C.SDL_GetJoystickPathForID(instance_id JoystickID) &char
 // See also: get_joystick_path (SDL_GetJoystickPath)
 // See also: get_joysticks (SDL_GetJoysticks)
 pub fn get_joystick_path_for_id(instance_id JoystickID) &char {
-	return C.SDL_GetJoystickPathForID(instance_id)
+	return &char(C.SDL_GetJoystickPathForID(instance_id))
 }
 
 // C.SDL_GetJoystickPlayerIndexForID [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetJoystickPlayerIndexForID)
@@ -647,7 +647,7 @@ fn C.SDL_GetJoystickName(joystick &Joystick) &char
 //
 // See also: get_joystick_name_for_id (SDL_GetJoystickNameForID)
 pub fn get_joystick_name(joystick &Joystick) &char {
-	return C.SDL_GetJoystickName(joystick)
+	return &char(C.SDL_GetJoystickName(joystick))
 }
 
 // C.SDL_GetJoystickPath [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetJoystickPath)
@@ -663,7 +663,7 @@ fn C.SDL_GetJoystickPath(joystick &Joystick) &char
 //
 // See also: get_joystick_path_for_id (SDL_GetJoystickPathForID)
 pub fn get_joystick_path(joystick &Joystick) &char {
-	return C.SDL_GetJoystickPath(joystick)
+	return &char(C.SDL_GetJoystickPath(joystick))
 }
 
 // C.SDL_GetJoystickPlayerIndex [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetJoystickPlayerIndex)
@@ -802,7 +802,7 @@ fn C.SDL_GetJoystickSerial(joystick &Joystick) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_joystick_serial(joystick &Joystick) &char {
-	return C.SDL_GetJoystickSerial(joystick)
+	return &char(C.SDL_GetJoystickSerial(joystick))
 }
 
 // C.SDL_GetJoystickType [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetJoystickType)

--- a/keyboard.c.v
+++ b/keyboard.c.v
@@ -83,7 +83,7 @@ fn C.SDL_GetKeyboardNameForID(instance_id KeyboardID) &char
 //
 // See also: get_keyboards (SDL_GetKeyboards)
 pub fn get_keyboard_name_for_id(instance_id KeyboardID) &char {
-	return C.SDL_GetKeyboardNameForID(instance_id)
+	return &char(C.SDL_GetKeyboardNameForID(instance_id))
 }
 
 // C.SDL_GetKeyboardFocus [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetKeyboardFocus)
@@ -133,7 +133,7 @@ fn C.SDL_GetKeyboardState(numkeys &int) &bool
 // See also: pump_events (SDL_PumpEvents)
 // See also: reset_keyboard (SDL_ResetKeyboard)
 pub fn get_keyboard_state(numkeys &int) &bool {
-	return C.SDL_GetKeyboardState(numkeys)
+	return &bool(C.SDL_GetKeyboardState(numkeys))
 }
 
 // C.SDL_ResetKeyboard [official documentation](https://wiki.libsdl.org/SDL3/SDL_ResetKeyboard)
@@ -292,7 +292,7 @@ fn C.SDL_GetScancodeName(scancode Scancode) &char
 // See also: get_scancode_from_name (SDL_GetScancodeFromName)
 // See also: set_scancode_name (SDL_SetScancodeName)
 pub fn get_scancode_name(scancode Scancode) &char {
-	return C.SDL_GetScancodeName(scancode)
+	return &char(C.SDL_GetScancodeName(scancode))
 }
 
 // C.SDL_GetScancodeFromName [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetScancodeFromName)
@@ -335,7 +335,7 @@ fn C.SDL_GetKeyName(key Keycode) &char
 // See also: get_key_from_scancode (SDL_GetKeyFromScancode)
 // See also: get_scancode_from_key (SDL_GetScancodeFromKey)
 pub fn get_key_name(key Keycode) &char {
-	return C.SDL_GetKeyName(key)
+	return &char(C.SDL_GetKeyName(key))
 }
 
 // C.SDL_GetKeyFromName [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetKeyFromName)

--- a/mouse.c.v
+++ b/mouse.c.v
@@ -182,7 +182,7 @@ fn C.SDL_GetMouseNameForID(instance_id MouseID) &char
 //
 // See also: get_mice (SDL_GetMice)
 pub fn get_mouse_name_for_id(instance_id MouseID) &char {
-	return C.SDL_GetMouseNameForID(instance_id)
+	return &char(C.SDL_GetMouseNameForID(instance_id))
 }
 
 // C.SDL_GetMouseFocus [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetMouseFocus)

--- a/pixels.c.v
+++ b/pixels.c.v
@@ -492,7 +492,7 @@ fn C.SDL_GetPixelFormatName(format PixelFormat) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_pixel_format_name(format PixelFormat) &char {
-	return C.SDL_GetPixelFormatName(format)
+	return &char(C.SDL_GetPixelFormatName(format))
 }
 
 // C.SDL_GetMasksForPixelFormat [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetMasksForPixelFormat)

--- a/platform.c.v
+++ b/platform.c.v
@@ -28,5 +28,5 @@ fn C.SDL_GetPlatform() &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_platform() &char {
-	return C.SDL_GetPlatform()
+	return &char(C.SDL_GetPlatform())
 }

--- a/properties.c.v
+++ b/properties.c.v
@@ -405,7 +405,7 @@ fn C.SDL_GetStringProperty(props PropertiesID, const_name &char, const_default_v
 // See also: has_property (SDL_HasProperty)
 // See also: set_string_property (SDL_SetStringProperty)
 pub fn get_string_property(props PropertiesID, const_name &char, const_default_value &char) &char {
-	return C.SDL_GetStringProperty(props, const_name, const_default_value)
+	return &char(C.SDL_GetStringProperty(props, const_name, const_default_value))
 }
 
 // C.SDL_GetNumberProperty [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetNumberProperty)

--- a/render.c.v
+++ b/render.c.v
@@ -123,7 +123,7 @@ fn C.SDL_GetRenderDriver(index int) &char
 //
 // See also: get_num_render_drivers (SDL_GetNumRenderDrivers)
 pub fn get_render_driver(index int) &char {
-	return C.SDL_GetRenderDriver(index)
+	return &char(C.SDL_GetRenderDriver(index))
 }
 
 // C.SDL_CreateWindowAndRenderer [official documentation](https://wiki.libsdl.org/SDL3/SDL_CreateWindowAndRenderer)
@@ -340,7 +340,7 @@ fn C.SDL_GetRendererName(renderer &Renderer) &char
 // See also: create_renderer (SDL_CreateRenderer)
 // See also: create_renderer_with_properties (SDL_CreateRendererWithProperties)
 pub fn get_renderer_name(renderer &Renderer) &char {
-	return C.SDL_GetRendererName(renderer)
+	return &char(C.SDL_GetRendererName(renderer))
 }
 
 // C.SDL_GetRendererProperties [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetRendererProperties)

--- a/sensor.c.v
+++ b/sensor.c.v
@@ -72,7 +72,7 @@ fn C.SDL_GetSensorNameForID(instance_id SensorID) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_sensor_name_for_id(instance_id SensorID) &char {
-	return C.SDL_GetSensorNameForID(instance_id)
+	return &char(C.SDL_GetSensorNameForID(instance_id))
 }
 
 // C.SDL_GetSensorTypeForID [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetSensorTypeForID)
@@ -160,7 +160,7 @@ fn C.SDL_GetSensorName(sensor &Sensor) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_sensor_name(sensor &Sensor) &char {
-	return C.SDL_GetSensorName(sensor)
+	return &char(C.SDL_GetSensorName(sensor))
 }
 
 // C.SDL_GetSensorType [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetSensorType)

--- a/stdinc.c.v
+++ b/stdinc.c.v
@@ -901,7 +901,7 @@ fn C.SDL_GetEnvironmentVariable(env &Environment, const_name &char) &char
 // See also: set_environment_variable (SDL_SetEnvironmentVariable)
 // See also: unset_environment_variable (SDL_UnsetEnvironmentVariable)
 pub fn get_environment_variable(env &Environment, const_name &char) &char {
-	return C.SDL_GetEnvironmentVariable(env, const_name)
+	return &char(C.SDL_GetEnvironmentVariable(env, const_name))
 }
 
 // C.SDL_GetEnvironmentVariables [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetEnvironmentVariables)
@@ -1011,7 +1011,7 @@ fn C.SDL_getenv(const_name &char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn getenv(const_name &char) &char {
-	return C.SDL_getenv(const_name)
+	return &char(C.SDL_getenv(const_name))
 }
 
 // C.SDL_getenv_unsafe [official documentation](https://wiki.libsdl.org/SDL3/SDL_getenv_unsafe)
@@ -1033,7 +1033,7 @@ fn C.SDL_getenv_unsafe(const_name &char) &char
 //
 // See also: getenv (SDL_getenv)
 pub fn getenv_unsafe(const_name &char) &char {
-	return C.SDL_getenv_unsafe(const_name)
+	return &char(C.SDL_getenv_unsafe(const_name))
 }
 
 // C.SDL_setenv_unsafe [official documentation](https://wiki.libsdl.org/SDL3/SDL_setenv_unsafe)
@@ -2349,7 +2349,7 @@ fn C.SDL_strdup(const_str &char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strdup(const_str &char) &char {
-	return C.SDL_strdup(const_str)
+	return &char(C.SDL_strdup(const_str))
 }
 
 // C.SDL_strndup [official documentation](https://wiki.libsdl.org/SDL3/SDL_strndup)
@@ -2377,7 +2377,7 @@ fn C.SDL_strndup(const_str &char, maxlen usize) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strndup(const_str &char, maxlen usize) &char {
-	return C.SDL_strndup(const_str, maxlen)
+	return &char(C.SDL_strndup(const_str, maxlen))
 }
 
 // C.SDL_strrev [official documentation](https://wiki.libsdl.org/SDL3/SDL_strrev)
@@ -2401,7 +2401,7 @@ fn C.SDL_strrev(str &char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strrev(str &char) &char {
-	return C.SDL_strrev(str)
+	return &char(C.SDL_strrev(str))
 }
 
 // C.SDL_strupr [official documentation](https://wiki.libsdl.org/SDL3/SDL_strupr)
@@ -2425,7 +2425,7 @@ fn C.SDL_strupr(str &char) &char
 //
 // See also: strlwr (SDL_strlwr)
 pub fn strupr(str &char) &char {
-	return C.SDL_strupr(str)
+	return &char(C.SDL_strupr(str))
 }
 
 // C.SDL_strlwr [official documentation](https://wiki.libsdl.org/SDL3/SDL_strlwr)
@@ -2449,7 +2449,7 @@ fn C.SDL_strlwr(str &char) &char
 //
 // See also: strupr (SDL_strupr)
 pub fn strlwr(str &char) &char {
-	return C.SDL_strlwr(str)
+	return &char(C.SDL_strlwr(str))
 }
 
 // C.SDL_strchr [official documentation](https://wiki.libsdl.org/SDL3/SDL_strchr)
@@ -2472,7 +2472,7 @@ fn C.SDL_strchr(const_str &char, c int) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strchr(const_str &char, c int) &char {
-	return C.SDL_strchr(const_str, c)
+	return &char(C.SDL_strchr(const_str, c))
 }
 
 // C.SDL_strrchr [official documentation](https://wiki.libsdl.org/SDL3/SDL_strrchr)
@@ -2494,7 +2494,7 @@ fn C.SDL_strrchr(const_str &char, c int) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strrchr(const_str &char, c int) &char {
-	return C.SDL_strrchr(const_str, c)
+	return &char(C.SDL_strrchr(const_str, c))
 }
 
 // C.SDL_strstr [official documentation](https://wiki.libsdl.org/SDL3/SDL_strstr)
@@ -2517,7 +2517,7 @@ fn C.SDL_strstr(const_haystack &char, const_needle &char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strstr(const_haystack &char, const_needle &char) &char {
-	return C.SDL_strstr(const_haystack, const_needle)
+	return &char(C.SDL_strstr(const_haystack, const_needle))
 }
 
 // C.SDL_strnstr [official documentation](https://wiki.libsdl.org/SDL3/SDL_strnstr)
@@ -2543,7 +2543,7 @@ fn C.SDL_strnstr(const_haystack &char, const_needle &char, maxlen usize) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strnstr(const_haystack &char, const_needle &char, maxlen usize) &char {
-	return C.SDL_strnstr(const_haystack, const_needle, maxlen)
+	return &char(C.SDL_strnstr(const_haystack, const_needle, maxlen))
 }
 
 // C.SDL_strcasestr [official documentation](https://wiki.libsdl.org/SDL3/SDL_strcasestr)
@@ -2574,7 +2574,7 @@ fn C.SDL_strcasestr(const_haystack &char, const_needle &char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strcasestr(const_haystack &char, const_needle &char) &char {
-	return C.SDL_strcasestr(const_haystack, const_needle)
+	return &char(C.SDL_strcasestr(const_haystack, const_needle))
 }
 
 // C.SDL_strtok_r [official documentation](https://wiki.libsdl.org/SDL3/SDL_strtok_r)
@@ -2606,7 +2606,7 @@ fn C.SDL_strtok_r(str &char, const_delim &char, saveptr &&char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strtok_r(str &char, const_delim &char, saveptr &&char) &char {
-	return C.SDL_strtok_r(str, const_delim, saveptr)
+	return &char(C.SDL_strtok_r(str, const_delim, saveptr))
 }
 
 // C.SDL_utf8strlen [official documentation](https://wiki.libsdl.org/SDL3/SDL_utf8strlen)
@@ -2704,7 +2704,7 @@ fn C.SDL_itoa(value int, str &char, radix int) &char
 // See also: ltoa (SDL_ltoa)
 // See also: lltoa (SDL_lltoa)
 pub fn itoa(value int, str &char, radix int) &char {
-	return C.SDL_itoa(value, str, radix)
+	return &char(C.SDL_itoa(value, str, radix))
 }
 
 // C.SDL_uitoa [official documentation](https://wiki.libsdl.org/SDL3/SDL_uitoa)
@@ -2735,7 +2735,7 @@ fn C.SDL_uitoa(value u32, str &char, radix int) &char
 // See also: ultoa (SDL_ultoa)
 // See also: ulltoa (SDL_ulltoa)
 pub fn uitoa(value u32, str &char, radix int) &char {
-	return C.SDL_uitoa(value, str, radix)
+	return &char(C.SDL_uitoa(value, str, radix))
 }
 
 // C.SDL_ltoa [official documentation](https://wiki.libsdl.org/SDL3/SDL_ltoa)
@@ -2766,7 +2766,7 @@ fn C.SDL_ltoa(value int, str &char, radix int) &char
 // See also: itoa (SDL_itoa)
 // See also: lltoa (SDL_lltoa)
 pub fn ltoa(value int, str &char, radix int) &char {
-	return C.SDL_ltoa(value, str, radix)
+	return &char(C.SDL_ltoa(value, str, radix))
 }
 
 // C.SDL_ultoa [official documentation](https://wiki.libsdl.org/SDL3/SDL_ultoa)
@@ -2797,7 +2797,7 @@ fn C.SDL_ultoa(value u32, str &char, radix int) &char
 // See also: uitoa (SDL_uitoa)
 // See also: ulltoa (SDL_ulltoa)
 pub fn ultoa(value u32, str &char, radix int) &char {
-	return C.SDL_ultoa(value, str, radix)
+	return &char(C.SDL_ultoa(value, str, radix))
 }
 
 // C.SDL_lltoa [official documentation](https://wiki.libsdl.org/SDL3/SDL_lltoa)
@@ -2828,7 +2828,7 @@ fn C.SDL_lltoa(value i64, str &char, radix int) &char
 // See also: itoa (SDL_itoa)
 // See also: ltoa (SDL_ltoa)
 pub fn lltoa(value i64, str &char, radix int) &char {
-	return C.SDL_lltoa(value, str, radix)
+	return &char(C.SDL_lltoa(value, str, radix))
 }
 
 // C.SDL_ulltoa [official documentation](https://wiki.libsdl.org/SDL3/SDL_ulltoa)
@@ -2859,7 +2859,7 @@ fn C.SDL_ulltoa(value u64, str &char, radix int) &char
 // See also: uitoa (SDL_uitoa)
 // See also: ultoa (SDL_ultoa)
 pub fn ulltoa(value u64, str &char, radix int) &char {
-	return C.SDL_ulltoa(value, str, radix)
+	return &char(C.SDL_ulltoa(value, str, radix))
 }
 
 // C.SDL_atoi [official documentation](https://wiki.libsdl.org/SDL3/SDL_atoi)
@@ -3238,7 +3238,7 @@ fn C.SDL_strpbrk(const_str &char, const_breakset &char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn strpbrk(const_str &char, const_breakset &char) &char {
-	return C.SDL_strpbrk(const_str, const_breakset)
+	return &char(C.SDL_strpbrk(const_str, const_breakset))
 }
 
 // The Unicode REPLACEMENT CHARACTER codepoint.
@@ -3365,7 +3365,7 @@ fn C.SDL_UCS4ToUTF8(codepoint u32, dst &char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn uc_s4_to_ut_f8(codepoint u32, dst &char) &char {
-	return C.SDL_UCS4ToUTF8(codepoint, dst)
+	return &char(C.SDL_UCS4ToUTF8(codepoint, dst))
 }
 
 // C.SDL_sscanf [official documentation](https://wiki.libsdl.org/SDL3/SDL_sscanf)
@@ -5363,7 +5363,7 @@ fn C.SDL_iconv_string(const_tocode &char, const_fromcode &char, const_inbuf &cha
 // See also: iconv_close (SDL_iconv_close)
 // See also: iconv (SDL_iconv)
 pub fn iconv_string(const_tocode &char, const_fromcode &char, const_inbuf &char, inbytesleft usize) &char {
-	return C.SDL_iconv_string(const_tocode, const_fromcode, const_inbuf, inbytesleft)
+	return &char(C.SDL_iconv_string(const_tocode, const_fromcode, const_inbuf, inbytesleft))
 }
 
 // Convert a UTF-8 string to the current locale's character encoding.

--- a/stdinc.c.v
+++ b/stdinc.c.v
@@ -3365,7 +3365,7 @@ fn C.SDL_UCS4ToUTF8(codepoint u32, dst &char) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn uc_s4_to_utf8(codepoint u32, dst &char) &char {
-  return &char(C.SDL_UCS4ToUTF8(codepoint, dst))
+	return &char(C.SDL_UCS4ToUTF8(codepoint, dst))
 }
 
 // C.SDL_sscanf [official documentation](https://wiki.libsdl.org/SDL3/SDL_sscanf)

--- a/thread.c.v
+++ b/thread.c.v
@@ -241,7 +241,7 @@ fn C.SDL_GetThreadName(thread_ &Thread) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_thread_name(thread_ &Thread) &char {
-	return C.SDL_GetThreadName(thread_)
+	return &char(C.SDL_GetThreadName(thread_))
 }
 
 // C.SDL_GetCurrentThreadID [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetCurrentThreadID)

--- a/touch.c.v
+++ b/touch.c.v
@@ -96,7 +96,7 @@ fn C.SDL_GetTouchDeviceName(touch_id TouchID) &char
 //
 // NOTE: This function is available since SDL 3.2.0.
 pub fn get_touch_device_name(touch_id TouchID) &char {
-	return C.SDL_GetTouchDeviceName(touch_id)
+	return &char(C.SDL_GetTouchDeviceName(touch_id))
 }
 
 // C.SDL_GetTouchDeviceType [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetTouchDeviceType)

--- a/video.c.v
+++ b/video.c.v
@@ -394,7 +394,7 @@ fn C.SDL_GetVideoDriver(index int) &char
 //
 // See also: get_num_video_drivers (SDL_GetNumVideoDrivers)
 pub fn get_video_driver(index int) &char {
-	return C.SDL_GetVideoDriver(index)
+	return &char(C.SDL_GetVideoDriver(index))
 }
 
 // C.SDL_GetCurrentVideoDriver [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetCurrentVideoDriver)
@@ -416,7 +416,7 @@ fn C.SDL_GetCurrentVideoDriver() &char
 // See also: get_num_video_drivers (SDL_GetNumVideoDrivers)
 // See also: get_video_driver (SDL_GetVideoDriver)
 pub fn get_current_video_driver() &char {
-	return C.SDL_GetCurrentVideoDriver()
+	return &char(C.SDL_GetCurrentVideoDriver())
 }
 
 // C.SDL_GetSystemTheme [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetSystemTheme)
@@ -434,7 +434,7 @@ pub fn get_system_theme() SystemTheme {
 }
 
 // C.SDL_GetDisplays [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetDisplays)
-fn C.SDL_GetDisplays(count &int) DisplayID
+fn C.SDL_GetDisplays(count &int) &DisplayID
 
 // get_displays gets a list of currently connected displays.
 //
@@ -447,7 +447,7 @@ fn C.SDL_GetDisplays(count &int) DisplayID
 // NOTE: (thread safety) This function should only be called on the main thread.
 //
 // NOTE: This function is available since SDL 3.2.0.
-pub fn get_displays(count &int) DisplayID {
+pub fn get_displays(count &int) &DisplayID {
 	return C.SDL_GetDisplays(count)
 }
 
@@ -518,7 +518,7 @@ fn C.SDL_GetDisplayName(display_id DisplayID) &char
 //
 // See also: get_displays (SDL_GetDisplays)
 pub fn get_display_name(display_id DisplayID) &char {
-	return C.SDL_GetDisplayName(display_id)
+	return &char(C.SDL_GetDisplayName(display_id))
 }
 
 // C.SDL_GetDisplayBounds [official documentation](https://wiki.libsdl.org/SDL3/SDL_GetDisplayBounds)
@@ -1632,7 +1632,7 @@ fn C.SDL_GetWindowTitle(window &Window) &char
 //
 // See also: set_window_title (SDL_SetWindowTitle)
 pub fn get_window_title(window &Window) &char {
-	return C.SDL_GetWindowTitle(window)
+	return &char(C.SDL_GetWindowTitle(window))
 }
 
 // C.SDL_SetWindowIcon [official documentation](https://wiki.libsdl.org/SDL3/SDL_SetWindowIcon)


### PR DESCRIPTION
- **examples: migrate to using `import sdl.callbacks`**
- **examples: fix more errors found with `-no-skip-unused -cstrict -cc clang-18`**
