### PR TITLE
general: add fallback and SDL3 support via `pkg-config` in `setup.vsh`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 60
     env:
-      SDL2_VERSION: 2.32.4
+      SDL2_VERSION: 2.32.6
       CFLAGS: -fpermissive -std=c99
     steps:
       - name: Checkout V

--- a/setup.vsh
+++ b/setup.vsh
@@ -2,28 +2,35 @@ import os
 
 os.chdir(os.dir(os.executable()))!
 
-res := os.execute('sdl2-config --version')
+mut res := os.execute('sdl2-config --version')
 if res.exit_code != 0 {
-	println('sdl2-config is missing')
-	exit(1)
+	println('sdl2-config is missing. Trying pkg-config...')
+	pkgconf := os.find_abs_path_of_executable('pkg-config') or { '' }
+	if !os.is_executable(pkgconf) {
+		println('pkg-config not found. Giving up')
+		exit(1)
+	}
+	res = os.execute('pkg-config --modversion sdl2')
+	if res.exit_code != 0 {
+		println('SDL2 is missing. Trying SDL3...')
+		res = os.execute('pkg-config --modversion sdl3')
+		if res.exit_code != 0 {
+			println('SDL3 is missing. Giving up')
+			exit(1)
+		}
+	}
 }
 system_version := res.output.trim_space()
 println('Your version is ${system_version}')
 
 remotes := os.execute('git branch -r --list')
 if remotes.exit_code != 0 {
-	println('git is missing')
+	println('git is missing. Giving up')
 	exit(1)
 }
-mut supported_versions := remotes.output.split_into_lines().map(it.trim_space()).filter(it.starts_with('origin/2')).map(it.all_after('origin/'))
-supported_versions.insert(0, '2.0.8') // master
+supported_versions := remotes.output.split_into_lines().map(it.trim_space()).filter(
+	it.starts_with('origin/2') || it.starts_with('origin/3')).map(it.all_after('origin/'))
 println('The SDL module officially supports these versions of SDL:\n   ${supported_versions}')
-
-if system_version == '2.0.8' {
-	println('Setting up the repository to branch master, that exactly matches your system SDL version 2.0.8')
-	os.system('git checkout master')
-	exit(0)
-}
 
 if system_version in supported_versions {
 	println('Setting up the repository to branch ${system_version} that exactly matches your system SDL version')


### PR DESCRIPTION
Tested in a Ubuntu 24.04 VM with SDL3 installed